### PR TITLE
Urbanization limited airports

### DIFF
--- a/common/buildings/mr_sports_civil_aviation_buildings.txt
+++ b/common/buildings/mr_sports_civil_aviation_buildings.txt
@@ -4,7 +4,7 @@ building_airport = {
 	building_group = bg_private_infrastructure	
 	icon = "gfx/interface/icons/building_icons/airport.dds"
 
-	expandable = no
+	# expandable = no
 
 	unlocking_technologies = {
 		curtiss_modern_aviation_tech
@@ -13,6 +13,50 @@ building_airport = {
 	production_method_groups = {
 		pmg_base_building_airport
 		pmg_cargo_airport
+	}
+	
+	can_build_government = {
+		custom_tooltip = {
+			text = mr_airport_can_construct_tt
+			NOT = {
+				b:building_airport ?= {
+					level_after_queued_constructions >= {
+						value = 1							# Ensures always 1 level is buildable
+						add = {
+							state.b:building_urban_center ?= {
+								add = level
+							}
+							divide = 10						# 1 additional level per 10 urban centres
+							floor = yes						# Otherwise this rounds UP for all decimals
+							# Whatever curtiss flight route variable you would like:
+							# add = var:curtiss_local_aviation_enthusiasm
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	can_build_private = {
+		custom_tooltip = {
+			text = mr_airport_can_construct_tt
+			NOT = {
+				b:building_airport ?= {
+					level_after_queued_constructions >= {
+						value = 1							# Ensures always 1 level is buildable
+						add = {
+							state.b:building_urban_center ?= {
+								add = level
+							}
+							divide = 10						# 1 additional level per 10 urban centres
+							floor = yes						# Otherwise this rounds UP for all decimals
+							# Whatever curtiss flight route variable you would like:
+							# add = var:curtiss_local_aviation_enthusiasm
+						}
+					}
+				}
+			}
+		}
 	}
 
 	required_construction = construction_cost_high

--- a/events/sports/curtiss_events.txt
+++ b/events/sports/curtiss_events.txt
@@ -599,6 +599,24 @@ curtiss.20 = {
 				name = curtiss_thriving_aviation_modifier
 				years = 5
 			}
+		# Example case for increasing max airport level
+		#	hidden_effect = {
+		#		if = { #Fallback if the variable does not exist yet
+		#			limit = {
+		#				NOT = {
+		#					has_variable = curtiss_local_aviation_enthusiasm
+		#				}
+		#			}
+		#			set_variable = {
+		#				name = curtiss_local_aviation_enthusiasm
+		#				value = 0
+		#			}
+		#		}
+		#		change_variable = {
+		#			name = curtiss_local_aviation_enthusiasm
+		#			add = 1
+		#		}
+		#	}
 		}
 		hidden_effect = {
 			random_list = {

--- a/localization/braz_por/localization_airports_l_braz_por.yml
+++ b/localization/braz_por/localization_airports_l_braz_por.yml
@@ -19,3 +19,4 @@
  goods_output_air_travel_add_desc: ""
  goods_input_air_travel_add: "Entrada de viagens aéreas por nível"
  goods_input_air_travel_add_desc: ""
+ mr_airport_can_construct_tt: "O nível máximo de [Concept('concept_curtiss_airport','$concept_curtiss_airports$')] que um estado pode suportar é igual a 1 mais 1 para cada #G 10 níveis#! de [GetBuildingType('building_urban_center').GetName]." #deepl:1884813676

--- a/localization/english/localization_airports_l_english.yml
+++ b/localization/english/localization_airports_l_english.yml
@@ -19,3 +19,4 @@
  goods_output_air_travel_add_desc: "" #1.8.6
  goods_input_air_travel_add: "Air Travel input per level" #1.8.6
  goods_input_air_travel_add_desc: "" #1.8.6
+ mr_airport_can_construct_tt: "The maximum level of [Concept('concept_curtiss_airport','$concept_curtiss_airports$')] that a state can support is equal to 1 plus 1 for every #G 10 levels#! of [GetBuildingType('building_urban_center').GetName]."

--- a/localization/french/localization_airports_l_french.yml
+++ b/localization/french/localization_airports_l_french.yml
@@ -19,3 +19,4 @@
  goods_output_air_travel_add_desc: ""
  goods_input_air_travel_add: "Entrée de voyage en avion par niveau"
  goods_input_air_travel_add_desc: ""
+ mr_airport_can_construct_tt: "Le niveau maximum de [Concept('concept_curtiss_airport','$concept_curtiss_airports$')] qu'un État peut supporter est égal à 1 plus 1 pour chaque #G 10 niveaux#! de [GetBuildingType('building_urban_center').GetName]." #deepl:1884813676

--- a/localization/german/localization_airports_l_german.yml
+++ b/localization/german/localization_airports_l_german.yml
@@ -19,3 +19,4 @@
  goods_output_air_travel_add_desc: ""
  goods_input_air_travel_add: "Flugreisen-Zufuhr"
  goods_input_air_travel_add_desc: ""
+ mr_airport_can_construct_tt: "Die maximale Stufe von [Concept('concept_curtiss_airport','$concept_curtiss_airports$')], die ein Staat unterstützen kann, entspricht 1 plus 1 für jede #G 10 Stufen#! von [GetBuildingType('building_urban_center').GetName]." #deepl:1884813676

--- a/localization/japanese/localization_airports_l_japanese.yml
+++ b/localization/japanese/localization_airports_l_japanese.yml
@@ -19,3 +19,4 @@
  goods_output_air_travel_add_desc: ""
  goods_input_air_travel_add: "Air Travel input per level"
  goods_input_air_travel_add_desc: ""
+ mr_airport_can_construct_tt: "州がサポートできる[Concept('concept_curtiss_airport','$concept_curtiss_airports$')] の最大レベルは、#G の10レベル#! ごとに1に1を加えたものに等しい[GetBuildingType('building_urban_center').GetName] 。" #deepl:1884813676

--- a/localization/korean/localization_airports_l_korean.yml
+++ b/localization/korean/localization_airports_l_korean.yml
@@ -19,3 +19,4 @@
  goods_output_air_travel_add_desc: ""
  goods_input_air_travel_add: "Air Travel input per level"
  goods_input_air_travel_add_desc: ""
+ mr_airport_can_construct_tt: "주에서 지원할 수 있는 최대 레벨 [Concept('concept_curtiss_airport','$concept_curtiss_airports$')] 은 #G 10레벨#! 의 [GetBuildingType('building_urban_center').GetName] 에 1을 더한 값과 같습니다." #deepl:1884813676

--- a/localization/polish/localization_airports_l_polish.yml
+++ b/localization/polish/localization_airports_l_polish.yml
@@ -19,3 +19,4 @@
  goods_output_air_travel_add_desc: ""
  goods_input_air_travel_add: "Air Travel input per level"
  goods_input_air_travel_add_desc: ""
+ mr_airport_can_construct_tt: "Maksymalny poziom [Concept('concept_curtiss_airport','$concept_curtiss_airports$')], który stan może obsługiwać, jest równy 1 plus 1 na każdy #G 10 poziomów#! [GetBuildingType('building_urban_center').GetName] ." #deepl:1884813676

--- a/localization/russian/localization_airports_l_russian.yml
+++ b/localization/russian/localization_airports_l_russian.yml
@@ -19,3 +19,4 @@
  goods_output_air_travel_add_desc: ""
  goods_input_air_travel_add: "Air Travel input per level"
  goods_input_air_travel_add_desc: ""
+ mr_airport_can_construct_tt: "Максимальный уровень [Concept('concept_curtiss_airport','$concept_curtiss_airports$')], который может поддерживать государство, равен 1 плюс 1 за каждые #G 10 уровней#! [GetBuildingType('building_urban_center').GetName] ." #deepl:1884813676

--- a/localization/simp_chinese/localization_airports_l_simp_chinese.yml
+++ b/localization/simp_chinese/localization_airports_l_simp_chinese.yml
@@ -19,3 +19,4 @@
  goods_output_air_travel_add_desc: ""
  goods_input_air_travel_add: "每级空旅投入"
  goods_input_air_travel_add_desc: ""
+ mr_airport_can_construct_tt: "一个州可支持的[Concept('concept_curtiss_airport','$concept_curtiss_airports$')] 最高级别等于 1 加 1，每 10 个#G #! [GetBuildingType('building_urban_center').GetName] 。" #deepl:1884813676

--- a/localization/spanish/localization_airports_l_spanish.yml
+++ b/localization/spanish/localization_airports_l_spanish.yml
@@ -19,3 +19,4 @@
  goods_output_air_travel_add_desc: ""
  goods_input_air_travel_add: "Entrada de viajes aéreos por nivel"
  goods_input_air_travel_add_desc: ""
+ mr_airport_can_construct_tt: "El nivel máximo de [Concept('concept_curtiss_airport','$concept_curtiss_airports$')] que puede soportar un estado es igual a 1 más 1 por cada #G 10 niveles#! de [GetBuildingType('building_urban_center').GetName]." #deepl:1884813676

--- a/localization/turkish/localization_airports_l_turkish.yml
+++ b/localization/turkish/localization_airports_l_turkish.yml
@@ -19,3 +19,4 @@
  goods_output_air_travel_add_desc: ""
  goods_input_air_travel_add: "Air Travel input per level"
  goods_input_air_travel_add_desc: ""
+ mr_airport_can_construct_tt: "Bir devletin destekleyebileceği maksimum [Concept('concept_curtiss_airport','$concept_curtiss_airports$')] seviyesi, [GetBuildingType('building_urban_center').GetName]'un her #G 10 seviyesi#! için 1 artı 1'e eşittir." #deepl:1884813676


### PR DESCRIPTION
For @MarcoDandolo's attention.

This makes it so that airports in each state are limited to 1 + 1 per 10 urban centre levels.
Feel free to adjust the values as you like, I have selected 10 because I feel that 10 is currently a good balance for the compatch with USU.
It does not show a maximum level, but the tooltip explains why you can't build any more when you reach that level.

I have included a commented line for using a variable to further control the maximum level at your discretion.
I have included a commented example in an event which seems like it might be appropriate for allowing higher levels.

Localization is included - does not cover the hypothetical variable component.