### PR TITLE
Rebalanced art methods

### DIFF
--- a/common/production_methods/artists_production_methods.txt
+++ b/common/production_methods/artists_production_methods.txt
@@ -17,6 +17,15 @@ pm_artists_arts_academy_standard = {
 	timed_modifiers = {
 		pm_artist_artistic_confusion_modifier
 	}
+
+	building_modifiers = {		# Use a 180/240 split
+		workforce_scaled = { 	# unscaled DOES NOT WORK (it just behaves as workforce scaled anyway)
+			# input goods
+			goods_input_paper_add = 6		# 180
+			goods_input_fabric_add = 12		# 240
+			goods_output_fine_art_add = 3	# 600
+		}
+	}
 }
 
 pm_artists_arts_academy_conservatory = {
@@ -36,11 +45,13 @@ pm_artists_arts_academy_conservatory = {
 		}
 	}
 
-	building_modifiers = {
-		unscaled = { 
+	building_modifiers = {		# Use a 180/240 split
+		workforce_scaled = { 	# unscaled DOES NOT WORK
 			# input goods
-			goods_input_elgar_instruments_add = 10
-		}				
+			goods_input_paper_add = 6					# 180
+			goods_input_elgar_instruments_add = 6		# 240
+			goods_output_fine_art_add = 3				# 600
+		}
 	}
 
 	ai_value = -1000
@@ -63,10 +74,12 @@ pm_artists_arts_academy_salon = {
 	}
 
 	building_modifiers = {
-		unscaled = { 
+		workforce_scaled = { 	# unscaled DOES NOT WORK
 			# input goods
-			goods_input_manzoni_prints_add = 10
-		}				
+			goods_input_paper_add = 6					# 180
+			goods_input_manzoni_prints_add = 4			# 240
+			goods_output_fine_art_add = 3				# 600
+		}
 	}
 
 	ai_value = -1000
@@ -90,10 +103,12 @@ pm_artists_arts_academy_studio = {
 	}
 
 	building_modifiers = {
-		unscaled = { 
+		workforce_scaled = { 	# unscaled DOES NOT WORK
 			# input goods
-			goods_input_dye_add = 10
-		}				
+			goods_input_paper_add = 6					# 180
+			goods_input_dye_add = 6						# 240
+			goods_output_fine_art_add = 3				# 600
+		}
 	}
 
 	ai_value = -1000
@@ -117,11 +132,12 @@ pm_artists_arts_academy_school = {
 	}
 
 	building_modifiers = {
-		unscaled = { 
+		workforce_scaled = { 	# unscaled DOES NOT WORK
 			# input goods
-			goods_input_paper_add = 5
-			goods_input_tools_add = 5
-		}				
+			goods_input_paper_add = 6					# 180
+			goods_input_tools_add = 6					# 240
+			goods_output_fine_art_add = 3				# 600
+		}
 	}
 
 	ai_value = -1000
@@ -138,6 +154,7 @@ pm_artists_sculptor_basic = {
 
 pm_artists_sculptor_modern = {
 	texture = "gfx/interface/icons/production_method_icons/artists_sculptor_modern.dds"
+	ai_value = 10000
 
 	unlocking_technologies = {
 		elgar_impressionism_tech
@@ -146,14 +163,19 @@ pm_artists_sculptor_modern = {
 	building_modifiers = {
 		unscaled = {
 			building_throughput_add = 0.05
-			building_employment_academics_add = 250
-			building_employment_clerks_add = 250
+		}
+		workforce_scaled = { 	# unscaled DOES NOT WORK
+			# input goods
+			goods_input_wood_add = 4					# 80
+			goods_input_tools_add = 2					# 80
+			goods_output_fine_art_add = 1				# 200
 		}
 	}
 }
 
 pm_artists_sculptor_art_deco = {
 	texture = "gfx/interface/icons/production_method_icons/artists_sculptor_art_deco.dds"
+	ai_value = 20000
 
 	unlocking_technologies = {
 		elgar_art_deco_tech
@@ -162,8 +184,13 @@ pm_artists_sculptor_art_deco = {
 	building_modifiers = {
 		unscaled = {
 			building_throughput_add = 0.15
-			building_employment_academics_add = 250
-			building_employment_clerks_add = 250
+		}
+		workforce_scaled = { 	# unscaled DOES NOT WORK
+			# input goods
+			goods_input_wood_add = 4					# 80
+			goods_input_lead_add = 2					# 80
+			goods_input_tools_add = 4					# 160
+			goods_output_fine_art_add = 2				# 400
 		}
 	}
 }


### PR DESCRIPTION
Objectives achieved here:

- Avoid touching the main vanilla pm line which MR did not touch yet
- Ensure the focuses don't actively harm the profitability (default focus needed comparable inputs)
- Disentangle the sculpture workshop bonuses from conflicting with each other at high wages (adding workforce while raising throughput results in some weird cases)
- Allow for a slightly higher profitability ceiling
- AI will now use sculpture workshop PM's

Notable numbers:

- Base price profitability was improved by 180 (all focuses are the same, but with the varied inputs)
- Sculpture workshop upgrades improve base profitability by 40 and then 80 points in addition to the throughput bonuses

Question:

- Why is the AI discouraged from using the specialist focuses?

Note:

- This is a save-game **_compatible_** change.