### PR TITLE
Prevent revolutions from taking Board Positions & Spamming Diplo actions

### DIFF
--- a/common/diplomatic_actions/mr_general_rapanui_diplomatic_actions.txt
+++ b/common/diplomatic_actions/mr_general_rapanui_diplomatic_actions.txt
@@ -20,6 +20,11 @@ catholic_mission_to_oceania = {
 	unlocking_technologies = {
 	}
 
+	selectable = {
+		NOT = { is_country_type = decentralized }
+		is_revolutionary = no
+	}
+
 	potential = {
 		country_has_state_religion = rel:catholic
 		NOT = {

--- a/common/diplomatic_actions/mr_science_academics_diplomatic_actions.txt
+++ b/common/diplomatic_actions/mr_science_academics_diplomatic_actions.txt
@@ -17,6 +17,11 @@ academics_recruit_foreign_scientist = {
 	show_effect_in_tooltip = yes
 
 	selectable = {
+		NOT = { is_country_type = decentralized }
+		is_revolutionary = no
+	}
+
+	selectable = {
 		trigger_if = {
 			limit = {
 				is_player = yes

--- a/common/diplomatic_actions/mr_science_andersson_diplomatic_actions.txt
+++ b/common/diplomatic_actions/mr_science_andersson_diplomatic_actions.txt
@@ -18,6 +18,11 @@ anthropological_invitation = {
 	unlocking_technologies = {
 	}
 
+	selectable = {
+		NOT = { is_country_type = decentralized }
+		is_revolutionary = no
+	}
+
 	potential = {
 		scope:target_country = {
 			has_technology_researched = lepsius_anthropology_tech

--- a/common/diplomatic_actions/mr_science_dubois_diplomatic_actions.txt
+++ b/common/diplomatic_actions/mr_science_dubois_diplomatic_actions.txt
@@ -19,6 +19,11 @@ paleontological_license = {
 		dubois_paleontology_tech
 	}
 
+	selectable = {
+		NOT = { is_country_type = decentralized }
+		is_revolutionary = no
+	}
+
 	potential = {
 		has_technology_researched = dubois_paleontology_tech
 		NOT = {

--- a/common/diplomatic_actions/mr_science_ito_diplomatic_actions.txt
+++ b/common/diplomatic_actions/mr_science_ito_diplomatic_actions.txt
@@ -21,6 +21,11 @@ ask_for_zoo_animal = {
 		dubois_theory_of_evolution_tech
 	}
 
+	selectable = {
+		NOT = { is_country_type = decentralized }
+		is_revolutionary = no
+	}
+
 	potential = {
 		trigger_if = {
 			limit = { is_ai = yes }

--- a/common/diplomatic_actions/mr_science_lepsius_diplomatic_actions.txt
+++ b/common/diplomatic_actions/mr_science_lepsius_diplomatic_actions.txt
@@ -21,6 +21,11 @@ excavation_license = {
 		lepsius_antiquarianism_tech
 	}
 
+	selectable = {
+		NOT = { is_country_type = decentralized }
+		is_revolutionary = no
+	}
+
 	potential = {
 		country_rank >= rank_value:major_power
 		trigger_if = {

--- a/common/diplomatic_actions/mr_sports_curtiss_diplomatic_actions.txt
+++ b/common/diplomatic_actions/mr_sports_curtiss_diplomatic_actions.txt
@@ -22,6 +22,11 @@ airspace_convention = {
 		curtiss_modern_aviation_tech
 	}
 
+	selectable = {
+		NOT = { is_country_type = decentralized }
+		is_revolutionary = no
+	}
+
 	potential = {
 		scope:target_country = {
 			has_technology_researched = curtiss_modern_aviation_tech

--- a/common/diplomatic_actions/mr_sports_douglas_diplomatic_actions.txt
+++ b/common/diplomatic_actions/mr_sports_douglas_diplomatic_actions.txt
@@ -19,6 +19,11 @@ mountaineering_license = {
 		nationalism
 	}
 
+	selectable = {
+		NOT = { is_country_type = decentralized }
+		is_revolutionary = no
+	}
+
 	potential = {
 		trigger_if = {
 			limit = { is_ai = yes }

--- a/common/scripted_effects/mr_sports_douglas_scripted_effects.txt
+++ b/common/scripted_effects/mr_sports_douglas_scripted_effects.txt
@@ -399,6 +399,7 @@ douglas_add_alpine_board_effect = {
 			NOT = {
 				has_variable = douglas_alpine_club_founding_country_var
 			}
+			is_revolutionary = no
 		}
 		order_by = douglas_alpine_board_member_quality_value
 		max = 5 #Limits the list to the three top countries
@@ -4908,7 +4909,10 @@ douglas_calculate_number_alpine_club_members_effect = {
 		value = 0
 	}
 	every_country = {
-		limit = { has_variable = douglas_mountaineering_club_var }
+		limit = {
+			has_variable = douglas_mountaineering_club_var
+			is_revolutionary = no
+		}
 		change_global_variable = {
 			name = douglas_num_alpine_club_members_global_var
 			add = 1

--- a/common/scripted_effects/mr_sports_vikelas_scripted_effects.txt
+++ b/common/scripted_effects/mr_sports_vikelas_scripted_effects.txt
@@ -626,7 +626,10 @@ vikelas_calculate_number_participants_effect = {
 		value = 0
 	}
 	every_country = {
-		limit = { has_variable = vikelas_ioc_member_var }
+		limit = {
+			has_variable = vikelas_ioc_member_var
+			is_revolutionary = no
+		}
 		change_global_variable = {
 			name = vikelas_olympic_participants_global_var
 			add = 1
@@ -644,7 +647,10 @@ vikelas_calculate_number_fifa_members_effect = {
 		value = 0
 	}
 	every_country = {
-		limit = { has_variable = vikelas_fifa_member_var }
+		limit = {
+			has_variable = vikelas_fifa_member_var
+			is_revolutionary = no
+		}
 		change_global_variable = {
 			name = vikelas_num_fifa_members_global_var
 			add = 1
@@ -659,7 +665,10 @@ vikelas_calculate_number_aiacr_members_effect = {
 		value = 0
 	}
 	every_country = {
-		limit = { has_variable = vikelas_automobile_club_var }
+		limit = {
+			has_variable = vikelas_automobile_club_var
+			is_revolutionary = no
+		}
 		change_global_variable = {
 			name = vikelas_num_aiacr_members_global_var
 			add = 1

--- a/events/sports/vikelas_events.txt
+++ b/events/sports/vikelas_events.txt
@@ -1694,6 +1694,7 @@ vikelas.111 = {
 			limit = {
 				country_rank = rank_value:great_power
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				NOR = {
 					has_variable = vikelas_ioc_board_member_var
 					has_variable = vikelas_ioc_founding_country_var
@@ -1705,6 +1706,7 @@ vikelas.111 = {
 			limit = {
 				country_rank = rank_value:great_power
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				NOT = {
 					has_variable = vikelas_ioc_board_member_var
 				}
@@ -1715,6 +1717,7 @@ vikelas.111 = {
 			limit = {
 				country_rank = rank_value:great_power
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				NOT = {
 					has_variable = vikelas_ioc_board_member_var
 				}
@@ -1725,6 +1728,7 @@ vikelas.111 = {
 			limit = {
 				country_rank = rank_value:great_power
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				NOT = {
 					has_variable = vikelas_ioc_board_member_var
 				}
@@ -1736,6 +1740,7 @@ vikelas.111 = {
 			limit = {
 				country_rank = rank_value:major_power
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				NOT = {
 					has_variable = vikelas_ioc_board_member_var
 				}
@@ -1746,6 +1751,7 @@ vikelas.111 = {
 			limit = {
 				country_rank = rank_value:major_power
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				NOT = {
 					has_variable = vikelas_ioc_board_member_var
 				}
@@ -1760,6 +1766,7 @@ vikelas.111 = {
 				}
 				has_variable = vikelas_ioc_member_var
 				country_is_in_europe = yes
+				is_revolutionary = no
 			}
 			set_variable = vikelas_ioc_board_member_var
 		}
@@ -1770,6 +1777,7 @@ vikelas.111 = {
 				}
 				has_variable = vikelas_ioc_member_var
 				country_is_in_europe = yes
+				is_revolutionary = no
 			}
 			set_variable = vikelas_ioc_board_member_var
 		}
@@ -1780,6 +1788,7 @@ vikelas.111 = {
 					has_variable = vikelas_ioc_board_member_var
 				}
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				OR = {
 					country_is_in_north_america = yes
 					country_is_in_central_america = yes
@@ -1794,6 +1803,7 @@ vikelas.111 = {
 					has_variable = vikelas_ioc_board_member_var
 				}
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				OR = {
 					country_is_in_north_america = yes
 					country_is_in_central_america = yes
@@ -1809,6 +1819,7 @@ vikelas.111 = {
 					has_variable = vikelas_ioc_board_member_var
 				}
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				OR = {
 					country_is_in_middle_east = yes
 					country_is_in_central_asia = yes
@@ -1825,6 +1836,7 @@ vikelas.111 = {
 					has_variable = vikelas_ioc_board_member_var
 				}
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				OR = {
 					country_is_in_middle_east = yes
 					country_is_in_central_asia = yes
@@ -1842,6 +1854,7 @@ vikelas.111 = {
 					has_variable = vikelas_ioc_board_member_var
 				}
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				country_is_in_africa = yes
 			}
 			set_variable = vikelas_ioc_board_member_var
@@ -1853,6 +1866,7 @@ vikelas.111 = {
 					has_variable = vikelas_ioc_board_member_var
 				}
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				rapanui_country_is_in_oceania = yes
 			}
 			set_variable = vikelas_ioc_board_member_var
@@ -1903,6 +1917,7 @@ vikelas.112 = {
 		random_country = {
 			limit = {
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				NOT = {
 					has_modifier = vikelas_olympics_hosted_modifier
 				}
@@ -1913,6 +1928,7 @@ vikelas.112 = {
 		random_country = {
 			limit = {
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				NOT = {
 					has_modifier = vikelas_olympics_hosted_modifier
 				}
@@ -1926,6 +1942,7 @@ vikelas.112 = {
 		random_country = {
 			limit = {
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				NOT = {
 					has_modifier = vikelas_olympics_hosted_modifier
 				}
@@ -1943,6 +1960,7 @@ vikelas.112 = {
 		random_country = {
 			limit = {
 				has_modifier = vikelas_olympics_bribed_modifier
+				is_revolutionary = no
 				NOT = {
 					has_modifier = vikelas_olympics_hosted_modifier
 				}
@@ -1957,6 +1975,7 @@ vikelas.112 = {
 		random_country = {
 			limit = {
 				has_variable = vikelas_ioc_member_var
+				is_revolutionary = no
 				NOT = {
 					has_modifier = vikelas_olympics_hosted_modifier
 				}


### PR DESCRIPTION
This prevents revolutions from:
- becoming Olympic Hosts (British Socialist Revolt cannot host no matter how impressive it looks on paper).
- becoming Board Members of the Mountaineering club and generally messing with mountaineering stuff.
- spamming requests to do paleontology/archeology/etc.