### PR TITLE
Add historical Japanese Baseball League (pre-1940) teams

### DIFF
--- a/common/customizable_localization/mr_sports_vikelas_customizable_localization.txt
+++ b/common/customizable_localization/mr_sports_vikelas_customizable_localization.txt
@@ -917,12 +917,68 @@ vikelas_historical_baseball_club_names_type = {
 		localization_key = vikelas_WI_milwaukee_brewers_loc
 	}
 
-	#Wyomonig
+	#Wyoming
 	text = {
 		trigger = {
-			state_region = s:STATE_WISCONSIN
+			state_region = s:STATE_WYOMING
 		}
 		localization_key = vikelas_WY_buffalo_untamed_loc
+	}
+
+	#Japan
+	text = {
+		trigger = {
+			state_region = s:STATE_KANTO
+		}
+		localization_key = vikelas_JP_kanto_dai_tokyo_loc
+	}
+	text = {
+		trigger = {
+			state_region = s:STATE_KANTO
+		}
+		localization_key = vikelas_JP_kanto_korakuen_eagles_loc
+	}
+	text = {
+		trigger = {
+			state_region = s:STATE_KANTO
+		}
+		localization_key = vikelas_JP_kanto_tokyo_kyojin_loc
+	}
+	text = {
+		trigger = {
+			state_region = s:STATE_KANTO
+		}
+		localization_key = vikelas_JP_kanto_tokyo_senators_loc
+	}
+	text = {
+		trigger = {
+			state_region = s:STATE_CHUBU
+		}
+		localization_key = vikelas_JP_chubu_nagoya_golden_dolphins_loc
+	}
+	text = {
+		trigger = {
+			state_region = s:STATE_CHUBU
+		}
+		localization_key = vikelas_JP_chubu_nagoya_baseball_club_loc
+	}
+	text = {
+		trigger = {
+			state_region = s:STATE_KANSAI
+		}
+		localization_key = vikelas_JP_kansai_hankyu_baseball_club_loc
+	}
+	text = {
+		trigger = {
+			state_region = s:STATE_KANSAI
+		}
+		localization_key = vikelas_JP_kansai_nankai_baseball_club_loc
+	}
+	text = {
+		trigger = {
+			state_region = s:STATE_KANSAI
+		}
+		localization_key = vikelas_JP_kansai_osaka_tigers_loc
 	}
 
 	#If no other loc is possible, this loc is chosen

--- a/localization/english/vikelas_sports_l_english.yml
+++ b/localization/english/vikelas_sports_l_english.yml
@@ -138,9 +138,9 @@
 
 #################################
 
-### Baseball Club Names ###
+ ### Baseball Clubs ###
 
-#Historic
+#USA
  vikelas_AL_alabama_crimson_tide_loc: "#V Alabama Crimson Tide#!"
  vikelas_AK_roaring_gimlets_loc: "#V Roaring Gimlets#!"
  vikelas_AZ_old_pueblos_loc: "#V Old Pueblos#!"
@@ -192,6 +192,17 @@
  vikelas_WA_seattle_rainiers_loc: "#V Seattle Rainiers#!"
  vikelas_WI_milwaukee_brewers_loc: "#V Milwaukee Brewers#!"
  vikelas_WY_buffalo_untamed_loc: "#V Buffalo Untamed#!"
+
+#Japan
+ vikelas_JP_kanto_dai_tokyo_loc: "#V Dai Tokyo#!"
+ vikelas_JP_kanto_korakuen_eagles_loc: "#V Korakuen Eagles#!"
+ vikelas_JP_kanto_tokyo_kyojin_loc: "#V Tokyo Kyojin#!"
+ vikelas_JP_kanto_tokyo_senators_loc: "#V Tokyo Senators#!"
+ vikelas_JP_chubu_nagoya_golden_dolphins_loc: "#V Nagoya Golden Dolphins#!"
+ vikelas_JP_chubu_nagoya_baseball_club_loc: "#V Nagoya Baseball Club#!"
+ vikelas_JP_kansai_hankyu_baseball_club_loc: "#V Hankyu Baseball Club#!"
+ vikelas_JP_kansai_nankai_baseball_club_loc: "#V Nankai Baseball Club#!"
+ vikelas_JP_kansai_osaka_tigers_loc: "#V Osaka Tigers#!"
 
 #generic
  vikelas_generic_baseball_club_names_loc: "[SCOPE.GetRootScope.GetState.GetCustom('vikelas_generic_baseball_club_names_type')]"


### PR DESCRIPTION
- Add historical Japanese Baseball League (pre-1940) teams from https://en.wikipedia.org/wiki/Japanese_Baseball_League
- Also fix Wisconsin getting Wyoming's baseball team