### PR TITLE
Ensure non-capital custom race tracks are actually built outside capital if available

### DIFF
--- a/common/scripted_effects/mr_sports_vikelas_scripted_effects.txt
+++ b/common/scripted_effects/mr_sports_vikelas_scripted_effects.txt
@@ -2042,6 +2042,66 @@ vikelas_add_circuit_effect = {
 	else_if = {
 		limit = {
 			OR = {
+				country_has_primary_culture = cu:south_italian
+				country_has_primary_culture = cu:north_italian
+			}
+			any_scope_state = {
+				state_region = s:STATE_ABRUZZO #Pescara
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_ABRUZZO
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:south_italian
+				country_has_primary_culture = cu:north_italian
+			}
+			any_scope_state = {
+				state_region = s:STATE_ROMAGNA #Imola
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_ROMAGNA
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:south_italian
+				country_has_primary_culture = cu:north_italian
+			}
+			any_scope_state = {
+				state_region = s:STATE_TUSCANY #Mugello
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_TUSCANY
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
 				country_has_primary_culture = cu:south_german
 				country_has_primary_culture = cu:north_german
 			}
@@ -2062,6 +2122,86 @@ vikelas_add_circuit_effect = {
 	else_if = {
 		limit = {
 			OR = {
+				country_has_primary_culture = cu:south_german
+				country_has_primary_culture = cu:north_german
+			}
+			any_scope_state = {
+				state_region = s:STATE_SAXONY #Badberg-Viereck
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_SAXONY
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:south_german
+				country_has_primary_culture = cu:north_german
+			}
+			any_scope_state = {
+				state_region = s:STATE_BADEN #Hockemheimring
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_BADEN
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:south_german
+				country_has_primary_culture = cu:north_german
+			}
+			any_scope_state = {
+				state_region = s:STATE_STYRIA #Zeltweg
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_STYRIA
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:south_german
+				country_has_primary_culture = cu:north_german
+			}
+			any_scope_state = {
+				state_region = s:STATE_HESSE #Opel-Rennbahn
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_HESSE
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
 				country_has_primary_culture = cu:yankee
 				country_has_primary_culture = cu:dixie
 			}
@@ -2072,6 +2212,246 @@ vikelas_add_circuit_effect = {
 		random_scope_state = {
 			limit = {
 				state_region = s:STATE_INDIANA
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:yankee
+				country_has_primary_culture = cu:dixie
+			}
+			any_scope_state = {
+				state_region = s:STATE_FLORIDA #Sebring
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_FLORIDA 
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:yankee
+				country_has_primary_culture = cu:dixie
+			}
+			any_scope_state = {
+				state_region = s:STATE_NEW_YORK #Long Island
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_NEW_YORK
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:yankee
+				country_has_primary_culture = cu:dixie
+			}
+			any_scope_state = {
+				state_region = s:STATE_WISCONSIN #Milwaukee Mile
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_WISCONSIN
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:yankee
+				country_has_primary_culture = cu:dixie
+			}
+			any_scope_state = {
+				state_region = s:STATE_IOWA #Knoxville
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_IOWA
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:yankee
+				country_has_primary_culture = cu:dixie
+			}
+			any_scope_state = {
+				state_region = s:STATE_PENNSYLVANIA #Uniontown
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_PENNSYLVANIA
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:yankee
+				country_has_primary_culture = cu:dixie
+			}
+			any_scope_state = {
+				state_region = s:STATE_CONNECTICUT #Thompson
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_CONNECTICUT
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:yankee
+				country_has_primary_culture = cu:dixie
+			}
+			any_scope_state = {
+				state_region = s:STATE_CALIFORNIA #Santa Monica
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_CALIFORNIA
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:yankee
+				country_has_primary_culture = cu:dixie
+			}
+			any_scope_state = {
+				state_region = s:STATE_MASSACHUSETTS #Seekonk
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_MASSACHUSETTS
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:yankee
+				country_has_primary_culture = cu:dixie
+			}
+			any_scope_state = {
+				state_region = s:STATE_NEW_HAMPSHIRE #Claremont
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_NEW_HAMPSHIRE
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:yankee
+				country_has_primary_culture = cu:dixie
+			}
+			any_scope_state = {
+				state_region = s:STATE_NORTH_CAROLINA #Bowman Gray
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_NORTH_CAROLINA
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:yankee
+				country_has_primary_culture = cu:dixie
+			}
+			any_scope_state = {
+				state_region = s:STATE_VIRGINIA #Langley
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_VIRGINIA
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:yankee
+				country_has_primary_culture = cu:dixie
+			}
+			any_scope_state = {
+				state_region = s:STATE_MAINE #Oxford Plains
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_MAINE
 			}
 			create_building = {
 				building = building_vikelas_circuit
@@ -2115,7 +2495,10 @@ vikelas_add_circuit_effect = {
 	}
 	else_if = {
 		limit = {
-			c:SPA ?= this
+			OR = {
+				c:SPA ?= this
+				country_has_primary_culture = cu:spanish
+			}
 			any_scope_state = {
 				state_region = s:STATE_BASQUE_COUNTRY #Lasarte
 			}
@@ -2123,6 +2506,40 @@ vikelas_add_circuit_effect = {
 		random_scope_state = {
 			limit = {
 				state_region = s:STATE_BASQUE_COUNTRY
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			country_has_primary_culture = cu:catalan
+			any_scope_state = {
+				state_region = s:STATE_CATALONIA #Sitges-Terramar
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_CATALONIA
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			country_has_primary_culture = cu:portuguese
+			any_scope_state = {
+				state_region = s:STATE_BEIRA #Boavista
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_BEIRA
 			}
 			create_building = {
 				building = building_vikelas_circuit
@@ -2140,6 +2557,81 @@ vikelas_add_circuit_effect = {
 		random_scope_state = {
 			limit = {
 				state_region = s:STATE_SAO_PAULO
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			country_has_primary_culture = cu:australian
+			any_scope_state = {
+				state_region = s:STATE_VICTORIA #Aspendale
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_VICTORIA
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				c:SAF ?= this
+				country_has_primary_culture = cu:boer
+			}
+			any_scope_state = {
+				state_region = s:STATE_CAPE_COLONY #Killarney
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_CAPE_COLONY
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				country_has_primary_culture = cu:amhara
+				country_has_primary_culture = cu:oromo
+				country_has_primary_culture = cu:tigray
+			}
+			any_scope_state = {
+				state_region = s:STATE_ERITREA #Asmara
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_ERITREA
+			}
+			create_building = {
+				building = building_vikelas_circuit
+				level = 1
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			country_has_primary_culture = cu:caribeno
+			any_scope_state = {
+				state_region = s:STATE_WESTERN_CUBA #Malecon
+			}
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_WESTERN_CUBA
 			}
 			create_building = {
 				building = building_vikelas_circuit


### PR DESCRIPTION
This PR ensures those non-capital state custom race tracks are actually built outside the capital if available (I only implement those which already exists in #172 for now)

This is ready for merging.