### PR TITLE
[WIP] Actual 1836-1935 Solar Eclipses

### DIFF
--- a/common/geographic_regions/verrier_solar_eclipses_regions.txt
+++ b/common/geographic_regions/verrier_solar_eclipses_regions.txt
@@ -1,0 +1,584 @@
+﻿##### 1836-1935 Annular/Total Solar Eclipse Regions #####
+
+## For full references, see the following references
+## https://eclipse.gsfc.nasa.gov/SEcat5/SE1801-1900.html
+## https://eclipse.gsfc.nasa.gov/SEcat5/SE1901-2000.html
+
+## Regions that should probably be splitted later: Oceania, North Sea Coast
+
+verrier_geographic_region_solar_eclipse_annular_1836_may = {
+	strategic_regions = {
+		sr:region_central_america
+		sr:region_caribbean
+		sr:region_north_sea_coast
+		sr:region_baltic
+		sr:region_poland
+		sr:region_belarus
+		sr:region_dnieper
+		sr:region_caucasus
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1836_nov = {
+	strategic_regions = {
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1838_sep = {
+	strategic_regions = {
+		sr:region_canada
+		sr:region_new_england
+		sr:region_the_midwest
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1839_mar = {
+	strategic_regions = {
+		sr:region_la_plata
+		sr:region_brazil
+		sr:region_senegal
+		sr:region_north_africa
+		sr:region_nile_basin
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1839_sep = {
+	strategic_regions = {
+		sr:region_japan
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1840_mar = {
+	strategic_regions = {
+		sr:region_madras
+		sr:region_indochina
+		sr:region_south_china
+		sr:region_north_china
+		sr:region_manchuria_china
+		sr:region_east_siberia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1840_aug = {
+	strategic_regions = {
+		sr:region_congo
+		sr:region_zanj
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1842_jul = {
+	strategic_regions = {
+		sr:region_iberia
+		sr:region_occitania
+		sr:region_italy
+		sr:region_south_germany
+		sr:region_danubia
+		sr:region_dnieper
+		sr:region_russia
+		sr:region_urals
+		sr:region_central_asia
+		sr:region_north_china
+		sr:region_south_china
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1842_dec = {
+	strategic_regions = {
+		sr:region_andes
+		sr:region_brazil
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1842_dec = {
+	strategic_regions = {
+		sr:region_andes
+		sr:region_brazil
+	}
+}
+
+verrier_geographic_region_solar_eclipse_hybrid_1846_apr = {
+	strategic_regions = {
+		sr:region_mexico
+		sr:region_central_america
+		sr:region_caribbean
+		sr:region_north_africa
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1846_oct = {
+	strategic_regions = {
+		sr:region_senegal
+		sr:region_congo
+		sr:region_zanj
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1847_apr = {
+	strategic_regions = {
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1847_oct = {
+	strategic_regions = {
+		sr:region_north_sea_coast
+		sr:region_england
+		sr:region_france
+		sr:region_south_germany
+		sr:region_italy
+		sr:region_balkans
+		sr:region_anatolia
+		sr:region_arabic
+		sr:region_persia
+		sr:region_bombay
+		sr:region_madras
+		sr:region_indochina
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1849_feb = {
+	strategic_regions = {
+		sr:region_himalayas
+		sr:region_south_china
+		sr:region_japan
+		sr:region_pacific_coast
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1850_feb = {
+	strategic_regions = {
+		sr:region_zanj
+		sr:region_indonesia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1850_aug = {
+	strategic_regions = {
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1851_feb = {
+	strategic_regions = {
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1851_jul = {
+	strategic_regions = {
+		sr:region_pacific_coast
+		sr:region_canada
+		sr:region_north_sea_coast
+		sr:region_baltic
+		sr:region_poland
+		sr:region_belarus
+		sr:region_dnieper
+		sr:region_caucasus
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1852_dec = {
+	strategic_regions = {
+		sr:region_west_siberia
+		sr:region_east_siberia
+		sr:region_north_africa
+		sr:region_manchuria_china
+		sr:region_japan
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1853_jun = {
+	strategic_regions = {
+		sr:region_andes
+		sr:region_brazil
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1853_nov = {
+	strategic_regions = {
+		sr:region_andes
+		sr:region_brazil
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1854_may = {
+	strategic_regions = {
+		sr:region_pacific_coast
+		sr:region_great_plains
+		sr:region_canada
+		sr:region_new_england
+	}
+}
+
+verrier_geographic_region_solar_eclipse_hybrid_1854_nov = {
+	strategic_regions = {
+		sr:region_brazil
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1856_apr = {
+	strategic_regions = {
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1856_sep = {
+	strategic_regions = {
+		sr:region_east_siberia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1857_mar = {
+	strategic_regions = {
+		sr:region_oceania
+		sr:region_mexico
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1857_sep = {
+	strategic_regions = {
+		sr:region_anatolia
+		sr:region_caucasus
+		sr:region_anatolia
+		sr:region_central_asia
+		sr:region_persia
+		sr:region_himalayas
+		sr:region_bengal
+		sr:region_indochina
+		sr:region_indonesia
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1858_mar = {
+	strategic_regions = {
+		sr:region_england
+		sr:region_baltic
+		sr:region_finland
+		sr:region_arctic_russia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1858_sep = {
+	strategic_regions = {
+		sr:region_andes
+		sr:region_brazil
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1860_jul = {
+	strategic_regions = {
+		sr:region_pacific_coast
+		sr:region_great_plains
+		sr:region_canada
+		sr:region_iberia
+		sr:region_north_africa
+		sr:region_nile_basin
+		sr:region_ethiopia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1861_jan = {
+	strategic_regions = {
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1861_jul = {
+	strategic_regions = {
+		sr:region_indochina
+		sr:region_indonesia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1861_dec = {
+	strategic_regions = {
+		sr:region_caribbean
+		sr:region_senegal
+		sr:region_north_africa
+		sr:region_balkans
+	}
+}
+
+verrier_geographic_region_solar_eclipse_hybrid_1864_may = {
+	strategic_regions = {
+		sr:region_indochina
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1864_oct = {
+	strategic_regions = {
+		sr:region_andes
+		sr:region_la_plata
+		sr:region_brazil
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1865_april = {
+	strategic_regions = {
+		sr:region_la_plata
+		sr:region_brazil
+		sr:region_congo
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1865_oct = {
+	strategic_regions = {
+		sr:region_pacific_coast
+		sr:region_the_midwest
+		sr:region_dixie
+		sr:region_senegal
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1867_mar = {
+	strategic_regions = {
+		sr:region_north_africa
+		sr:region_italy
+		sr:region_balkans
+		sr:region_danubia
+		sr:region_dnieper
+		sr:region_russia
+		sr:region_urals
+		sr:region_west_siberia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1867_aug = {
+	strategic_regions = {
+		sr:region_la_plata
+		sr:region_brazil
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1868_feb = {
+	strategic_regions = {
+		sr:region_andes
+		sr:region_brazil
+		sr:region_senegal
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1868_aug = {
+	strategic_regions = {
+		sr:region_ethiopia
+		sr:region_arabic
+		sr:region_bombay
+		sr:region_madras
+		sr:region_indochina
+		sr:region_indonesia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1869_feb = {
+	strategic_regions = {
+		sr:region_southern_africa
+		sr:region_zanj
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1869_aug = {
+	strategic_regions = {
+		sr:region_east_siberia
+		sr:region_pacific_coast
+		sr:region_great_plains
+		sr:region_the_midwest
+		sr:region_dixie
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1870_dec = {
+	strategic_regions = {
+		sr:region_iberia
+		sr:region_north_africa
+		sr:region_italy
+		sr:region_balkans
+		sr:region_anatolia
+		sr:region_dnieper
+		sr:region_caucasus
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1871_jun = {
+	strategic_regions = {
+		sr:region_indonesia
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1871_dec = {
+	strategic_regions = {
+		sr:region_madras
+		sr:region_indonesia
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1872_jun = {
+	strategic_regions = {
+		sr:region_madras
+		sr:region_indochina
+		sr:region_south_china
+		sr:region_north_china
+		sr:region_manchuria_china
+		sr:region_japan
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1874_apr = {
+	strategic_regions = {
+		sr:region_southern_africa
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1874_oct = {
+	strategic_regions = {
+		sr:region_west_siberia
+		sr:region_central_asia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1875_apr = {
+	strategic_regions = {
+		sr:region_indochina
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1875_sep = {
+	strategic_regions = {
+		sr:region_new_england
+		sr:region_senegal
+		sr:region_congo
+		sr:region_zanj
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1876_mar = {
+	strategic_regions = {
+		sr:region_oceania
+		sr:region_pacific_coast
+		sr:region_great_plains
+		sr:region_canada
+		sr:region_north_sea_coast
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1878_feb = {
+	strategic_regions = {
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1878_jul = {
+	strategic_regions = {
+		sr:region_east_siberia
+		sr:region_pacific_coast
+		sr:region_great_plains
+		sr:region_dixie
+		sr:region_caribbean
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1879_jan = {
+	strategic_regions = {
+		sr:region_la_plata
+		sr:region_brazil
+		sr:region_southern_africa
+		sr:region_congo
+		sr:region_zanj
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1879_jul = {
+	strategic_regions = {
+		sr:region_senegal
+		sr:region_nile_basin
+		sr:region_ethiopia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1880_jan = {
+	strategic_regions = {
+		sr:region_pacific_coast
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1882_may = {
+	strategic_regions = {
+		sr:region_senegal
+		sr:region_north_africa
+		sr:region_nile_basin
+		sr:region_arabic
+		sr:region_persia
+		sr:region_central_asia
+		sr:region_north_china
+		sr:region_south_china
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1882_nov = {
+	strategic_regions = {
+		sr:region_indonesia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1883_oct = {
+	strategic_regions = {
+		sr:region_manchuria_china
+		sr:region_japan
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1885_mar = {
+	strategic_regions = {
+		sr:region_pacific_coast
+		sr:region_great_plains
+		sr:region_canada
+		sr:region_north_sea_coast
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1885_sep = {
+	strategic_regions = {
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1886_mar = {
+	strategic_regions = {
+		sr:region_mexico
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1886_aug = {
+	strategic_regions = {
+		sr:region_gran_colombia
+		sr:region_congo
+		sr:region_southern_africa
+		sr:region_zanj
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1887_feb = {
+	strategic_regions = {
+		sr:region_andes
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1887_aug = {
+	strategic_regions = {
+		sr:region_north_germany
+		sr:region_poland
+		sr:region_baltic_states
+		sr:region_russia
+		sr:region_urals
+		sr:region_west_siberia
+		sr:region_east_siberia
+		sr:region_north_china
+		sr:region_manchuria_china
+		sr:region_japan
+	}
+}

--- a/common/geographic_regions/verrier_solar_eclipses_regions.txt
+++ b/common/geographic_regions/verrier_solar_eclipses_regions.txt
@@ -13,17 +13,28 @@ verrier_geographic_region_solar_eclipse_annular_1836_may = {
 		sr:region_central_america
 		sr:region_caribbean
 		sr:region_north_sea_coast
-		sr:region_baltic
+		sr:region_england
+		sr:region_rhine
+		sr:region_north_germany
 		sr:region_poland
 		sr:region_belarus
 		sr:region_dnieper
 		sr:region_caucasus
 	}
+	state_regions = {
+		STATE_JUTLAND
+		STATE_ZEALAND
+		STATE_SCANIA
+		STATE_GOTALAND
+		STATE_KAUNAS
+		STATE_VILNIUS
+		STATE_URALSK
+	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1836_nov = {
-	strategic_regions = {
-		sr:region_oceania
+	state_regions = {
+		STATE_WESTERN_AUSTRALIA
 	}
 }
 
@@ -32,6 +43,12 @@ verrier_geographic_region_solar_eclipse_annular_1838_sep = {
 		sr:region_canada
 		sr:region_new_england
 		sr:region_the_midwest
+	}
+	state_regions = {
+		STATE_VIRGINIA
+		STATE_NORTH_CAROLINA
+		STATE_SOUTH_CAROLINA
+		STATE_BERMUDA
 	}
 }
 
@@ -48,25 +65,52 @@ verrier_geographic_region_solar_eclipse_total_1839_mar = {
 verrier_geographic_region_solar_eclipse_annular_1839_sep = {
 	strategic_regions = {
 		sr:region_japan
-		sr:region_oceania
+	}
+	state_regions = {
+		STATE_SEOUL
+		STATE_YANGHO
+		STATE_BUSAN
+		STATE_HAWAIIAN_ISLANDS
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1840_mar = {
 	strategic_regions = {
 		sr:region_madras
-		sr:region_indochina
-		sr:region_south_china
-		sr:region_north_china
-		sr:region_manchuria
-		sr:region_east_siberia
+		sr:region_bengal
+	}
+	state_regions = {
+		STATE_ARAKAN
+		STATE_MANDALAY
+		STATE_KACHIN
+		STATE_SHAN_STATES
+		STATE_EASTERN_HIMALAYAS
+		STATE_LHASA
+		STATE_YUNNAN
+		STATE_SICHUAN
+		STATE_CHONGQING
+		STATE_XIAN
+		STATE_SHANXI
+		STATE_BEIJING
+		STATE_NORTHERN_MANCHURIA
+		STATE_AMUR
+		STATE_OKHOTSK
+		STATE_CHUKOTKA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1840_aug = {
-	strategic_regions = {
-		sr:region_congo
-		sr:region_zanj
+	state_regions = {
+		STATE_NORTH_ANGOLA
+		STATE_SOUTH_ANGOLA
+		STATE_EAST_ANGOLA
+		STATE_KATANGA
+		STATE_ZAMBIA
+		STATE_KAZEMBE
+		STATE_MOCAMBIQUE
+		STATE_LINDI
+		STATE_ZANZIBAR
+		STATE_NORTH_MADAGASCAR
 	}
 }
 
@@ -74,71 +118,164 @@ verrier_geographic_region_solar_eclipse_total_1842_jul = {
 	strategic_regions = {
 		sr:region_iberia
 		sr:region_occitania
+		sr:region_france
 		sr:region_italy
 		sr:region_south_germany
+		sr:region_north_germany
+		sr:region_poland
 		sr:region_danubia
 		sr:region_dnieper
 		sr:region_russia
 		sr:region_urals
-		sr:region_central_asia
-		sr:region_north_china
-		sr:region_south_china
+	}
+	state_regions = {
+		STATE_SLOVENIA
+		STATE_DALMATIA
+		STATE_CROATIA
+		STATE_SLAVONIA
+		STATE_BOSNIA
+		STATE_WESTERN_SERBIA
+		STATE_EASTERN_SERBIA
+		STATE_MONTENEGRO
+		STATE_KOSOVO
+		STATE_KAUNAS
+		STATE_VILNIUS
+		STATE_ROSTOV
+		STATE_AKTOBE
+		STATE_AKMOLINSK
+		STATE_SEMIRECHE
+		STATE_DZUNGARIA
+		STATE_EASTERN_HUBEI
+		STATE_SOUTHERN_ANHUI
+		STATE_ZHEJIANG
+		STATE_FUJIAN
+		STATE_FORMOSA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1842_dec = {
-	strategic_regions = {
-		sr:region_andes
-		sr:region_brazil
+	state_regions = {
+		STATE_TARAPACA
+		STATE_POTOSI
+		STATE_LA_PAZ
+		STATE_SANTA_CRUZ
+		STATE_MATO_GROSSO
+		STATE_AMAZONAS
+		STATE_PARA
 	}
 }
 
-verrier_geographic_region_solar_eclipse_annular_1842_dec = {
+verrier_geographic_region_solar_eclipse_hybrid_1843_jun = {
 	strategic_regions = {
 		sr:region_andes
-		sr:region_brazil
+	}
+	state_regions = {
+		STATE_ALTO_PARAGUAY
+		STATE_BAJO_PARAGUAY
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1843_dec = {
+	state_regions = {
+		STATE_NEJD
+		STATE_ABU_DHABI
+		STATE_OMAN
+		STATE_ACEH
+		STATE_TENASSERIM
+		STATE_CAMBODIA
+		STATE_MEKONG
 	}
 }
 
 verrier_geographic_region_solar_eclipse_hybrid_1846_apr = {
-	strategic_regions = {
-		sr:region_mexico
-		sr:region_central_america
-		sr:region_caribbean
-		sr:region_north_africa
+	state_regions = {
+		STATE_SAN_SALVADOR
+		STATE_GUATEMALA
+		STATE_HONDURAS
+		STATE_OAXACA
+		STATE_CHIAPAS
+		STATE_YUCATAN
+		STATE_WESTERN_CUBA
+		STATE_CENTRAL_CUBA
+		STATE_EASTERN_CUBA
+		STATE_BAHAMAS
+		STATE_BERMUDA
+		STATE_WEST_SAHARA
+		STATE_INNER_MAURITANIA
+		STATE_SAHARA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1846_oct = {
 	strategic_regions = {
 		sr:region_senegal
-		sr:region_niger
-		sr:region_congo
 		sr:region_zanj
-		sr:region_oceania
+	}
+	state_regions = {
+		STATE_TOGO
+		STATE_DAHOMEY
+		STATE_YORUBA_STATES
+		STATE_NIGER_DELTA
+		STATE_SOUTH_CAMEROON
+		STATE_NORTH_CAMEROON
+		STATE_CONGO
+		STATE_EQUATEUR
+		STATE_CONGO_ORIENTALE
+		STATE_WESTERN_AUSTRALIA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1847_apr = {
-	strategic_regions = {
-		sr:region_oceania
+	state_regions = {
+		STATE_SUNDA_ISLANDS
+		STATE_NORTHERN_TERRITORY
+		STATE_QUEENSLAND
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1847_oct = {
 	strategic_regions = {
-		sr:region_north_sea_coast
 		sr:region_england
 		sr:region_france
+		sr:region_rhine
 		sr:region_south_germany
-		sr:region_italy
+		sr:region_danubia
 		sr:region_balkans
 		sr:region_anatolia
-		sr:region_arabic
-		sr:region_persia
 		sr:region_bombay
-		sr:region_madras
-		sr:region_indochina
+	}
+	state_regions = {
+		STATE_CONNAUGHT
+		STATE_LEINSTER
+		STATE_MUNSTER
+		STATE_SAVOY
+		STATE_PIEDMONT
+		STATE_LOMBARDY
+		STATE_SOUTH_TYROL
+		STATE_VENETIA
+		STATE_EMILIA
+		STATE_TUSCANY
+		STATE_ROMAGNA
+		STATE_ALEPPO
+		STATE_SYRIA
+		STATE_DEIR_EZ_ZOR
+		STATE_BAGHDAD
+		STATE_BASRA
+		STATE_MOSUL
+		STATE_ABU_DHABI
+		STATE_OMAN
+		STATE_KHUZESTAN
+		STATE_FARS
+		STATE_LARISTAN
+		STATE_HYDERABAD
+		STATE_KURNOOL
+		STATE_CIRCARS
+		STATE_PEGU
+		STATE_CHIANG_MAI
+		STATE_BANGKOK
+		STATE_NAKHON_RATCHASIMA
+		STATE_LAOS
+		STATE_ANNAM
 	}
 }
 
@@ -147,112 +284,224 @@ verrier_geographic_region_solar_eclipse_annular_1849_feb = {
 		sr:region_himalayas
 		sr:region_south_china
 		sr:region_japan
-		sr:region_pacific_coast
+	}
+	state_regions = {
+		STATE_SEOUL
+		STATE_YANGHO
+		STATE_BUSAN
+		STATE_ALASKA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1850_feb = {
-	strategic_regions = {
-		sr:region_zanj
-		sr:region_indonesia
+	state_regions = {
+		STATE_EAST_ANGOLA
+		STATE_KATANGA
+		STATE_ZAMBIA
+		STATE_KAZEMBE
+		STATE_MOCAMBIQUE
+		STATE_NORTH_MADAGASCAR
+		STATE_NORTH_SUMATRA
+		STATE_MALAYA
+		STATE_EAST_BORNEO
+		STATE_NORTH_BORNEO
+		STATE_LUZON
+		STATE_VISAYAS
+		STATE_MINDANAO
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1850_aug = {
-	strategic_regions = {
-		sr:region_oceania
+	state_regions = {
+		STATE_WEST_MICRONESIA
+		STATE_EAST_MICRONESIA
+		STATE_HAWAIIAN_ISLANDS
+		STATE_CAJAMARCA
+		STATE_LIMA
+		STATE_ICA
+		STATE_AREQUIPA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1851_feb = {
-	strategic_regions = {
-		sr:region_oceania
+	state_regions = {
+		STATE_NEW_SOUTH_WALES
+		STATE_VICTORIA
+		STATE_TASMANIA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1851_jul = {
 	strategic_regions = {
-		sr:region_pacific_coast
-		sr:region_canada
-		sr:region_north_sea_coast
 		sr:region_baltic
+		sr:region_rhine
+		sr:region_north_germany
 		sr:region_poland
+		sr:region_baltic_states
 		sr:region_belarus
 		sr:region_dnieper
 		sr:region_caucasus
+		sr:region_balkans
+		sr:region_anatolia
+		sr:region_central_asia
+	}
+	state_regions = {
+		STATE_ALASKA
+		STATE_NORTHWEST_TERRITORIES
+		STATE_NUNAVUT
+		STATE_GREENLAND
+		STATE_ICELAND
+		STATE_HIGHLANDS
+		STATE_LOWLANDS
+		STATE_UUSIMAA
+		STATE_KUOPIO
+		STATE_OSTROBOTHNIA
+		STATE_PSKOV
+		STATE_INGRIA
+		STATE_MOSUL
+		STATE_ISFAHAN
+		STATE_MAZANDARAN
+		STATE_IRAKAJEMI
+		STATE_SEMNAN
+		STATE_TABRIZ
+		STATE_URMIA
+		STATE_LURISTAN
+		STATE_PERSIAN_KURDISTAN
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1852_dec = {
 	strategic_regions = {
-		sr:region_west_siberia
-		sr:region_east_siberia
-		sr:region_north_africa
+		sr:region_north_china
 		sr:region_manchuria
 		sr:region_japan
+	}
+	state_regions = {
+		STATE_KRASNOYARSK
+		STATE_UPPER_YENISEYSK
+		STATE_YAKUTSK
+		STATE_TRANS_BAIKAL
+		STATE_IRKUTSK
+		STATE_BURYATIA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1853_jun = {
-	strategic_regions = {
-		sr:region_andes
-		sr:region_brazil
+	state_regions = {
+		STATE_TONGA
+		STATE_ECUADOR
+		STATE_PASTAZA
+		STATE_ACRE
+		STATE_AMAZONAS
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1853_nov = {
-	strategic_regions = {
-		sr:region_andes
-		sr:region_brazil
+	state_regions = {
+		STATE_HAWAIIAN_ISLANDS
+		STATE_ICA
+		STATE_LIMA
+		STATE_AREQUIPA
+		STATE_MATO_GROSSO
+		STATE_PARA
+		STATE_MARANHAO
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1854_may = {
 	strategic_regions = {
-		sr:region_pacific_coast
-		sr:region_great_plains
-		sr:region_canada
 		sr:region_new_england
+	}
+	state_regions = {
+		STATE_WASHINGTON
+		STATE_BRITISH_COLUMBIA
+		STATE_IDAHO
+		STATE_ALBERTA
+		STATE_SASKATCHEWAN
+		STATE_MANITOBA
+		STATE_MONTANA
+		STATE_NORTH_DAKOTA
+		STATE_WISCONSIN
+		STATE_ONTARIO
 	}
 }
 
 verrier_geographic_region_solar_eclipse_hybrid_1854_nov = {
-	strategic_regions = {
-		sr:region_brazil
+	state_regions = {
+		STATE_BAHIA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1856_apr = {
-	strategic_regions = {
-		sr:region_oceania
+	state_regions = {
+		STATE_WESTERN_AUSTRALIA
+		STATE_SOUTH_AUSTRALIA
+		STATE_NORTHERN_TERRITORY
+		STATE_QUEENSLAND
+		STATE_KANAK
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1856_sep = {
-	strategic_regions = {
-		sr:region_east_siberia
+	state_regions = {
+		STATE_KAMCHATKA
+		STATE_CHUKOTKA
+		STATE_ALASKA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1857_mar = {
-	strategic_regions = {
-		sr:region_oceania
-		sr:region_mexico
+	state_regions = {
+		STATE_SOUTH_AUSTRALIA
+		STATE_VICTORIA
+		STATE_NEW_SOUTH_WALES
+		STATE_FIJI
+		STATE_TONGA
+		STATE_BAJA_CALIFORNIA
+		STATE_SINALOA
+		STATE_DURANGO
+		STATE_JALISCO
+		STATE_MEXICO
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1857_sep = {
 	strategic_regions = {
 		sr:region_anatolia
-		sr:region_caucasus
-		sr:region_anatolia
-		sr:region_central_asia
-		sr:region_persia
-		sr:region_himalayas
 		sr:region_bengal
-		sr:region_indochina
-		sr:region_indonesia
-		sr:region_oceania
+	}
+	state_regions = {
+		STATE_GREATER_CAUCASUS
+		STATE_ARMENIA
+		STATE_ELIZAVETPOL
+		STATE_AZERBAIJAN
+		STATE_LURISTAN
+		STATE_URMIA
+		STATE_TABRIZ
+		STATE_MAZANDARAN
+		STATE_KHORASAN
+		STATE_TURKMENIA
+		STATE_MERZ
+		STATE_HERAT
+		STATE_CENTRAL_HIGHLANDS
+		STATE_KABUL
+		STATE_PASHTUNISTAN
+		STATE_PUNJAB
+		STATE_KASHMIR
+		STATE_HILL_PUNJAB
+		STATE_DELHI
+		STATE_AGRA
+		STATE_HIMALAYAS
+		STATE_ARAKAN
+		STATE_MANDALAY
+		STATE_TENASSERIM
+		STATE_BANGKOK
+		STATE_MALAYA
+		STATE_EAST_BORNEO
+		STATE_EAST_JAVA
+		STATE_SUNDA_ISLANDS
+		STATE_NORTHERN_TERRITORY
+		STATE_QUEENSLAND
 	}
 }
 
@@ -260,40 +509,88 @@ verrier_geographic_region_solar_eclipse_annular_1858_mar = {
 	strategic_regions = {
 		sr:region_england
 		sr:region_baltic
+		sr:region_rhine
 		sr:region_finland
 		sr:region_arctic_russia
+	}
+	state_regions = {
+		STATE_ZULIA
+		STATE_MIRANDA
+		STATE_WEST_INDIES
+		STATE_MADEIRA
+		STATE_BEIRA
+		STATE_ENTRE_DOURO_E_MINHO
+		STATE_GALICIA
+		STATE_BRITTANY
+		STATE_NORMANDY
+		STATE_PICARDY
+		STATE_FRENCH_LOW_COUNTRIES
+		STATE_HANNOVER
+		STATE_ELBE
+		STATE_SCHLESWIG_HOLSTEIN
+		STATE_TALINN
+		STATE_TARTU
+		STATE_INGRIA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1858_sep = {
 	strategic_regions = {
 		sr:region_andes
-		sr:region_brazil
+	}
+	state_regions = {
+		STATE_ACRE
+		STATE_MATO_GROSSO
+		STATE_PARANA
+		STATE_SAO_PAULO
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1860_jul = {
 	strategic_regions = {
 		sr:region_pacific_coast
-		sr:region_great_plains
 		sr:region_canada
+		sr:region_occitania
 		sr:region_iberia
 		sr:region_north_africa
 		sr:region_nile_basin
 		sr:region_ethiopia
 	}
+	state_regions = {
+		STATE_ALBERTA
+		STATE_SASKATCHEWAN
+		STATE_MONTANA
+		STATE_CONNAUGHT
+		STATE_MUNSTER
+		STATE_LEINSTER
+		STATE_ULSTER
+		STATE_WALES
+		STATE_WEST_COUNTRY
+		STATE_BRITTANY
+		STATE_NORMANDY
+		STATE_MAINE_ANJOU
+		STATE_SARDINIA
+		STATE_CORSICA
+		STATE_SICILY
+		STATE_HEDJAZ
+		STATE_YEMEN
+	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1861_jan = {
-	strategic_regions = {
-		sr:region_oceania
+	state_regions = {
+		STATE_SOUTH_AUSTRALIA
+		STATE_QUEENSLAND
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1861_jul = {
-	strategic_regions = {
-		sr:region_indochina
-		sr:region_indonesia
+	state_regions = {
+		STATE_ACEH
+		STATE_TENASSERIM
+		STATE_MALAYA
+		STATE_LUZON
+		STATE_VISAYAS
 	}
 }
 
@@ -301,134 +598,290 @@ verrier_geographic_region_solar_eclipse_total_1861_dec = {
 	strategic_regions = {
 		sr:region_caribbean
 		sr:region_senegal
-		sr:region_north_africa
 		sr:region_balkans
+	}
+	state_regions = {
+		STATE_MIRANDA
+		STATE_SAHARA
+		STATE_EAST_SAHARA
+		STATE_TUNISIA
+		STATE_TRIPOLI
+		STATE_MALTA
+		STATE_SICILY
+		STATE_CALABRIA
+		STATE_WALLACHIA
+		STATE_DOBRUDJA
+		STATE_EASTERN_THRACE
+		STATE_HUDAVENDIGAR
+		STATE_AYDIN
+		STATE_KONYA
+		STATE_EAST_AEGEAN_ISLANDS
 	}
 }
 
 verrier_geographic_region_solar_eclipse_hybrid_1864_may = {
-	strategic_regions = {
-		sr:region_indochina
+	state_regions = {
+		STATE_ACEH
+		STATE_MALAYA
+		STATE_NORTH_SUMATRA
+		STATE_NORTH_BORNEO
+		STATE_VISAYAS
+		STATE_MINDANAO
+		STATE_BAJA_CALIFORNIA
+		STATE_SONORA
+		STATE_SINALOA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1864_oct = {
 	strategic_regions = {
 		sr:region_andes
-		sr:region_la_plata
-		sr:region_brazil
+	}
+	state_regions = {
+		STATE_CHACO
+		STATE_ALTO_PARAGUAY
+		STATE_BAJO_PARAGUAY
+		STATE_CORRIENTES
+		STATE_SANTA_CATARINA
+		STATE_PARANA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1865_april = {
-	strategic_regions = {
-		sr:region_la_plata
-		sr:region_brazil
-		sr:region_congo
+	state_regions = {
+		STATE_LOS_RIOS
+		STATE_PATAGONIA
+		STATE_RIO_NEGRO
+		STATE_BUENOS_AIRES
+		STATE_LA_PAMPA
+		STATE_SANTA_FE
+		STATE_CORRIENTES
+		STATE_BAJO_PARAGUAY
+		STATE_URUGUAY
+		STATE_RIO_GRANDE_DO_SUL
+		STATE_SANTA_CATARINA
+		STATE_PARANA
+		STATE_SAO_PAULO
+		STATE_RIO_DE_JANEIRO
+		STATE_NORTH_ANGOLA
+		STATE_SOUTH_ANGOLA
+		STATE_EAST_ANGOLA
+		STATE_KATANGA
+		STATE_ZAMBIA
+		STATE_KAZEMBE
+		STATE_MOCAMBIQUE
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1865_oct = {
 	strategic_regions = {
 		sr:region_pacific_coast
+		sr:region_great_plains
 		sr:region_the_midwest
 		sr:region_dixie
-		sr:region_senegal
+	}
+	state_regions = {
+		STATE_SENEGAL
+		STATE_MAURITANIA
+		STATE_INNER_MAURITANIA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1867_mar = {
 	strategic_regions = {
 		sr:region_north_africa
+		sr:region_iberia
 		sr:region_italy
 		sr:region_balkans
 		sr:region_danubia
 		sr:region_dnieper
 		sr:region_russia
 		sr:region_urals
+		sr:region_arctic_russia
 		sr:region_west_siberia
+	}
+	state_regions = {
+		STATE_STYRIA
+		STATE_TYROL
+		STATE_AUSTRIA
+		STATE_EASTERN_THRACE
+		STATE_EAST_GALICIA
+		STATE_WEST_GALICIA
+		STATE_ROSTOV
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1867_aug = {
 	strategic_regions = {
 		sr:region_la_plata
-		sr:region_brazil
+	}
+	state_regions = {
+		STATE_URUGUAY
+		STATE_RIO_GRANDE_DO_SUL
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1868_feb = {
-	strategic_regions = {
-		sr:region_andes
-		sr:region_brazil
-		sr:region_senegal
-		sr:region_niger
+	state_regions = {
+		STATE_LIMA
+		STATE_ICA
+		STATE_AREQUIPA
+		STATE_LA_PAZ
+		STATE_MATO_GROSSO
+		STATE_GOIAS
+		STATE_BAHIA
+		STATE_PIAUI
+		STATE_PARAIBA
+		STATE_RIO_GRANDE_DO_NORTE
+		STATE_PERNAMBUCO
+		STATE_LIBERIA
+		STATE_SIERRA_LEONE
+		STATE_GUINEA
+		STATE_VOLTA
+		STATE_WINDWARD_COAST
+		STATE_IVORY_COAST
+		STATE_EASTERN_MALI
+		STATE_NIGER
+		STATE_OUTER_HAUSALAND
+		STATE_HAUSALAND
+		STATE_EAST_HAUSALAND
+		STATE_BORNU
+		STATE_CHAD
+		STATE_DARFUR
+		STATE_LIBYAN_DESERT
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1868_aug = {
 	strategic_regions = {
 		sr:region_ethiopia
-		sr:region_arabic
-		sr:region_bombay
 		sr:region_madras
-		sr:region_indochina
-		sr:region_indonesia
+	}
+	state_regions = {
+		STATE_YEMEN
+		STATE_BOMBAY
+		STATE_PEGU
+		STATE_BANGKOK
+		STATE_TENASSERIM
+		STATE_CAMBODIA
+		STATE_MEKONG
+		STATE_NORTH_BORNEO
+		STATE_WEST_BORNEO
+		STATE_CELEBES
+		STATE_MOLUCCAS
+		STATE_WESTERN_NEW_GUINEA
+		STATE_EASTERN_NEW_GUINEA
+		STATE_QUEENSLAND
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1869_feb = {
-	strategic_regions = {
-		sr:region_southern_africa
-		sr:region_zanj
+	state_regions = {
+		STATE_CAPE_COLONY
+		STATE_EASTERN_CAPE
+		STATE_NORTHERN_CAPE
+		STATE_VRYSTAAT
+		STATE_ZULULAND
+		STATE_SOUTH_MADAGASCAR
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1869_aug = {
 	strategic_regions = {
 		sr:region_east_siberia
-		sr:region_pacific_coast
 		sr:region_great_plains
 		sr:region_the_midwest
 		sr:region_dixie
+	}
+	state_regions = {
+		STATE_NORTHERN_MANCHURIA
+		STATE_AMUR
+		STATE_ALASKA
+		STATE_YUKON_TERRITORY
+		STATE_BRITISH_COLUMBIA
+		STATE_NEW_YORK
+		STATE_NEW_JERSEY
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1870_dec = {
 	strategic_regions = {
 		sr:region_iberia
-		sr:region_north_africa
+		sr:region_occitania
+		sr:region_south_germany
 		sr:region_italy
 		sr:region_balkans
+		sr:region_danubia
 		sr:region_anatolia
 		sr:region_dnieper
 		sr:region_caucasus
+		sr:region_russia
+	}
+	state_regions = {
+		STATE_MARRAKECH
+		STATE_FEZ
+		STATE_AL_RIF
+		STATE_ORAN
+		STATE_ALGIERS
+		STATE_CONSTANTINE
+		STATE_TRIPOLI
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1871_jun = {
-	strategic_regions = {
-		sr:region_indonesia
-		sr:region_oceania
+	state_regions = {
+		STATE_SUNDA_ISLANDS
+		STATE_EASTERN_NEW_GUINEA
+		STATE_WESTERN_NEW_GUINEA
+		STATE_BOUGAINVILLE
+		STATE_EAST_MICRONESIA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1871_dec = {
 	strategic_regions = {
 		sr:region_madras
-		sr:region_indonesia
-		sr:region_oceania
+	}
+	state_regions = {
+		STATE_OMAN
+		STATE_ABU_DHABI
+		STATE_ACEH
+		STATE_NORTH_SUMATRA
+		STATE_SOUTH_SUMATRA
+		STATE_WEST_JAVA
+		STATE_CENTRAL_JAVA
+		STATE_EAST_JAVA
+		STATE_SUNDA_ISLANDS
+		STATE_NORTHERN_TERRITORY
+		STATE_QUEENSLAND
+		STATE_EASTERN_NEW_GUINEA
+		STATE_BOUGAINVILLE
+		STATE_SOLOMON_ISLANDS
+		STATE_EAST_MICRONESIA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1872_jun = {
 	strategic_regions = {
 		sr:region_madras
-		sr:region_indochina
+		sr:region_bengal
 		sr:region_south_china
 		sr:region_north_china
 		sr:region_manchuria
-		sr:region_japan
+	}
+	state_regions = {
+		STATE_KACHIN
+		STATE_SHAN_STATES
+		STATE_MANDALAY
+		STATE_HOKKAIDO
+		STATE_TOHOKU
+	}
+}
+
+verrier_geographic_region_solar_eclipse_hybrid_1872_nov = {
+	state_regions = {
+		STATE_ARAUCANIA
+		STATE_SOUTH_ATLANTIC_ISLANDS
 	}
 }
 
@@ -446,33 +899,69 @@ verrier_geographic_region_solar_eclipse_annular_1874_oct = {
 }
 
 verrier_geographic_region_solar_eclipse_total_1875_apr = {
-	strategic_regions = {
-		sr:region_indochina
+	state_regions = {
+		STATE_TENASSERIM
+		STATE_CHIANG_MAI
+		STATE_BANGKOK
+		STATE_NAKHON_RATCHASIMA
+		STATE_LAOS
+		STATE_CAMBODIA
+		STATE_ANNAM
+		STATE_GUANGDONG
+		STATE_FORMOSA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1875_sep = {
 	strategic_regions = {
 		sr:region_new_england
-		sr:region_senegal
-		sr:region_congo
-		sr:region_zanj
+	}
+	state_regions = {
+		STATE_ONTARIO
+		STATE_NEW_BRUNSWICK
+		STATE_MAURITANIA
+		STATE_SENEGAL
+		STATE_GUINEA
+		STATE_SIERRA_LEONE
+		STATE_LIBERIA
+		STATE_WINDWARD_COAST
+		STATE_IVORY_COAST
+		STATE_EAST_ANGOLA
+		STATE_NORTH_ANGOLA
+		STATE_SOUTH_ANGOLA
+		STATE_ZAMBIA
+		STATE_KAZEMBE
+		STATE_MOCAMBIQUE
+		STATE_ZAMBEZIA
+		STATE_NORTH_MADAGASCAR
+		STATE_SOUTH_MADAGASCAR
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1876_mar = {
-	strategic_regions = {
-		sr:region_oceania
-		sr:region_pacific_coast
-		sr:region_great_plains
-		sr:region_canada
-		sr:region_north_sea_coast
+	state_regions = {
+		STATE_HAWAIIAN_ISLANDS
+		STATE_BRITISH_COLUMBIA
+		STATE_YUKON_TERRITORY
+		STATE_NORTHWEST_TERRITORIES
+		STATE_ALBERTA
+		STATE_NUNAVUT
+		STATE_GREENLAND
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1876_sep = {
+	state_regions = {
+		STATE_SOLOMON_ISLANDS
+		STATE_WEST_MICRONESIA
+		STATE_EAST_MICRONESIA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1878_feb = {
-	strategic_regions = {
-		sr:region_oceania
+	state_regions = {
+		STATE_TASMANIA
+		STATE_VICTORIA
 	}
 }
 
@@ -484,57 +973,154 @@ verrier_geographic_region_solar_eclipse_total_1878_jul = {
 		sr:region_dixie
 		sr:region_caribbean
 	}
+	state_regions = {
+		STATE_YUCATAN
+	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1879_jan = {
-	strategic_regions = {
-		sr:region_la_plata
-		sr:region_brazil
-		sr:region_southern_africa
-		sr:region_congo
-		sr:region_zanj
+	state_regions = {
+		STATE_CHACO
+		STATE_LA_PAMPA
+		STATE_TUCUMAN
+		STATE_SANTIAGO
+		STATE_SANTA_FE
+		STATE_CORRIENTES
+		STATE_URUGUAY
+		STATE_RIO_GRANDE_DO_SUL
+		STATE_NAMAQUALAND
+		STATE_HEREROLAND
+		STATE_BOTSWANA
+		STATE_ZAMBIA
+		STATE_KAZEMBE
+		STATE_KATANGA
+		STATE_LINDI
+		STATE_ZANZIBAR
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1879_jul = {
 	strategic_regions = {
-		sr:region_senegal
-		sr:region_niger
-		sr:region_nile_basin
 		sr:region_ethiopia
+	}
+	state_regions = {
+		STATE_GUINEA
+		STATE_SIERRA_LEONE
+		STATE_WESTERN_MALI
+		STATE_EASTERN_MALI
+		STATE_TIMBUKTU
+		STATE_OUTER_HAUSALAND
+		STATE_NIGER
+		STATE_CHAD
+		STATE_DARFUR
+		STATE_DONGOLA
+		STATE_KORDOFAN
+		STATE_BLUE_NILE
+		STATE_YEMEN
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1880_jan = {
-	strategic_regions = {
-		sr:region_pacific_coast
+	state_regions = {
+		STATE_CALIFORNIA
+		STATE_NEVADA
+		STATE_UTAH
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1880_jul = {
+	state_regions = {
+		STATE_SOUTH_ATLANTIC_ISLANDS
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1882_may = {
 	strategic_regions = {
-		sr:region_senegal
-		sr:region_niger
-		sr:region_north_africa
-		sr:region_nile_basin
-		sr:region_arabic
-		sr:region_persia
-		sr:region_central_asia
 		sr:region_north_china
-		sr:region_south_china
+	}
+	state_regions = {
+		STATE_VOLTA
+		STATE_OUTER_HAUSALAND
+		STATE_NIGER
+		STATE_WINDWARD_COAST
+		STATE_IVORY_COAST
+		STATE_GHANA
+		STATE_DAHOMEY
+		STATE_TOGO
+		STATE_HAUSALAND
+		STATE_EAST_HAUSALAND
+		STATE_BORNU
+		STATE_CHAD
+		STATE_LIBYAN_DESERT
+		STATE_UPPER_EGYPT
+		STATE_EGYPTIAN_DESERT
+		STATE_LOWER_EGYPT
+		STATE_MATRUH
+		STATE_MIDDLE_EGYPT
+		STATE_SINAI
+		STATE_HEDJAZ
+		STATE_HAIL
+		STATE_TRANSJORDAN
+		STATE_PALESTINE
+		STATE_BASRA
+		STATE_BAGHDAD
+		STATE_DEIR_EZ_ZOR
+		STATE_MOSUL
+		STATE_KHUZESTAN
+		STATE_LURISTAN
+		STATE_PERSIAN_KURDISTAN
+		STATE_ISFAHAN
+		STATE_IRAKAJEMI
+		STATE_SEMNAN
+		STATE_KHORASAN
+		STATE_TABRIZ
+		STATE_AZERBAIJAN
+		STATE_URMIA
+		STATE_MAZANDARAN
+		STATE_ELIZAVETPOL
+		STATE_TURKMENIA
+		STATE_MERZ
+		STATE_UZBEKIA
+		STATE_TAJIKISTAN
+		STATE_KIRGHIZIA
+		STATE_KABUL
+		STATE_TIANSHAN
+		STATE_SUZHOU
+		STATE_KYUSHU
+		STATE_RYUKYU_ISLANDS
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1882_nov = {
-	strategic_regions = {
-		sr:region_indonesia
+	state_regions = {
+		STATE_CELEBES
+		STATE_MOLUCCAS
+		STATE_EASTERN_NEW_GUINEA
+		STATE_WESTERN_NEW_GUINEA
+		STATE_KANAK
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1883_may = {
+	state_regions = {
+		STATE_NEW_SOUTH_WALES
+		STATE_EAST_MICRONESIA
+		STATE_WEST_MICRONESIA
+		STATE_TONGA
+		STATE_ICA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1883_oct = {
 	strategic_regions = {
-		sr:region_manchuria
 		sr:region_japan
+	}
+	state_regions = {
+		STATE_SARIWON
+		STATE_PYONGYANG
+		STATE_SEOUL
+		STATE_STATE_SOUTHERN_MANCHURIA
+		STATE_OUTER_MANCHURIA
 	}
 }
 
@@ -542,29 +1128,59 @@ verrier_geographic_region_solar_eclipse_annular_1885_mar = {
 	strategic_regions = {
 		sr:region_pacific_coast
 		sr:region_great_plains
-		sr:region_canada
-		sr:region_north_sea_coast
+	}
+	state_regions = {
+		STATE_ONTARIO
+		STATE_MANITOBA
+		STATE_NUNAVUT
+		STATE_GREENLAND
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1885_sep = {
-	strategic_regions = {
-		sr:region_oceania
+	state_regions = {
+		STATE_TASMANIA
+		STATE_NORTH_ISLAND
+		STATE_SOUTH_ISLAND
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1886_mar = {
-	strategic_regions = {
-		sr:region_mexico
+	state_regions = {
+		STATE_BOUGAINVILLE
+		STATE_EAST_MICRONESIA
+		STATE_WEST_MICRONESIA
+		STATE_TONGA
+		STATE_BAJIO
+		STATE_VERACRUZ
+		STATE_MEXICO
+		STATE_OAXACA
+		STATE_GUERRERO
+		STATE_JALISCO
+		STATE_YUCATAN
+		STATE_WESTERN_CUBA
+		STATE_CENTRAL_CUBA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1886_aug = {
-	strategic_regions = {
-		sr:region_gran_colombia
-		sr:region_congo
-		sr:region_southern_africa
-		sr:region_zanj
+	state_regions = {
+		STATE_NICARAGUA
+		STATE_HONDURAS
+		STATE_COSTA_RICA
+		STATE_PANAMA
+		STATE_ANTIOQUIA
+		STATE_ZULIA
+		STATE_MIRANDA
+		STATE_WEST_INDIES
+		STATE_NORTH_ANGOLA
+		STATE_SOUTH_ANGOLA
+		STATE_EAST_ANGOLA
+		STATE_ZAMBIA
+		STATE_ZAMBEZI
+		STATE_ZAMBEZIA
+		STATE_LOURENCO_MARQUES
+		STATE_SOUTH_MADAGASCAR
 	}
 }
 
@@ -1102,7 +1718,7 @@ verrier_geographic_region_solar_eclipse_total_1934_feb = {
 	state_regions = {
 		STATE_ACEH
 		STATE_TENASSERIM
-		STATE_STATE_MALAYA
+		STATE_MALAYA
 		STATE_NORTH_BORNEO
 		STATE_WEST_BORNEO
 		STATE_EAST_BORNEO

--- a/common/geographic_regions/verrier_solar_eclipses_regions.txt
+++ b/common/geographic_regions/verrier_solar_eclipses_regions.txt
@@ -4,7 +4,9 @@
 ## https://eclipse.gsfc.nasa.gov/SEcat5/SE1801-1900.html
 ## https://eclipse.gsfc.nasa.gov/SEcat5/SE1901-2000.html
 
-## Regions that should probably be splitted later: Oceania, North Sea Coast
+## >=80% obscuration criteria for 50% of the whole strategic region,
+## else particular states with >80% for 100% of the state 
+## or was 100% for a period are assigned individually
 
 verrier_geographic_region_solar_eclipse_annular_1836_may = {
 	strategic_regions = {
@@ -56,7 +58,7 @@ verrier_geographic_region_solar_eclipse_annular_1840_mar = {
 		sr:region_indochina
 		sr:region_south_china
 		sr:region_north_china
-		sr:region_manchuria_china
+		sr:region_manchuria
 		sr:region_east_siberia
 	}
 }
@@ -110,6 +112,7 @@ verrier_geographic_region_solar_eclipse_hybrid_1846_apr = {
 verrier_geographic_region_solar_eclipse_annular_1846_oct = {
 	strategic_regions = {
 		sr:region_senegal
+		sr:region_niger
 		sr:region_congo
 		sr:region_zanj
 		sr:region_oceania
@@ -185,7 +188,7 @@ verrier_geographic_region_solar_eclipse_total_1852_dec = {
 		sr:region_west_siberia
 		sr:region_east_siberia
 		sr:region_north_africa
-		sr:region_manchuria_china
+		sr:region_manchuria
 		sr:region_japan
 	}
 }
@@ -359,6 +362,7 @@ verrier_geographic_region_solar_eclipse_annular_1868_feb = {
 		sr:region_andes
 		sr:region_brazil
 		sr:region_senegal
+		sr:region_niger
 	}
 }
 
@@ -423,7 +427,7 @@ verrier_geographic_region_solar_eclipse_annular_1872_jun = {
 		sr:region_indochina
 		sr:region_south_china
 		sr:region_north_china
-		sr:region_manchuria_china
+		sr:region_manchuria
 		sr:region_japan
 	}
 }
@@ -495,6 +499,7 @@ verrier_geographic_region_solar_eclipse_annular_1879_jan = {
 verrier_geographic_region_solar_eclipse_annular_1879_jul = {
 	strategic_regions = {
 		sr:region_senegal
+		sr:region_niger
 		sr:region_nile_basin
 		sr:region_ethiopia
 	}
@@ -509,6 +514,7 @@ verrier_geographic_region_solar_eclipse_total_1880_jan = {
 verrier_geographic_region_solar_eclipse_total_1882_may = {
 	strategic_regions = {
 		sr:region_senegal
+		sr:region_niger
 		sr:region_north_africa
 		sr:region_nile_basin
 		sr:region_arabic
@@ -527,7 +533,7 @@ verrier_geographic_region_solar_eclipse_annular_1882_nov = {
 
 verrier_geographic_region_solar_eclipse_annular_1883_oct = {
 	strategic_regions = {
-		sr:region_manchuria_china
+		sr:region_manchuria
 		sr:region_japan
 	}
 }
@@ -578,7 +584,536 @@ verrier_geographic_region_solar_eclipse_total_1887_aug = {
 		sr:region_west_siberia
 		sr:region_east_siberia
 		sr:region_north_china
-		sr:region_manchuria_china
+		sr:region_manchuria
 		sr:region_japan
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1889_jan = {
+	strategic_regions = {
+		sr:region_pacific_coast
+		sr:region_great_plains
+		sr:region_canada
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1889_jun = {
+	strategic_regions = {
+		sr:region_southern_africa
+		sr:region_zanj
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1889_dec = {
+	strategic_regions = {
+		sr:region_gran_colombia
+		sr:region_caribbean
+		sr:region_congo
+		sr:region_zanj
+		sr:region_ethiopia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1890_jun = {
+	strategic_regions = {
+		sr:region_senegal
+		sr:region_north_africa
+		sr:region_balkans
+		sr:region_anatolia
+		sr:region_persia
+		sr:region_punjab
+		sr:region_central_india
+		sr:region_bengal
+		sr:region_indochina
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1891_jun = {
+	strategic_regions = {
+		sr:region_east_siberia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1893_apr = {
+	strategic_regions = {
+		sr:region_la_plata
+		sr:region_brazil
+		sr:region_senegal
+		sr:region_niger
+		sr:region_nile_basin
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1893_oct = {
+	strategic_regions = {
+		sr:region_andes
+	}
+}
+
+verrier_geographic_region_solar_eclipse_hybrid_1894_apr = {
+	strategic_regions = {
+		sr:region_madras
+		sr:region_bengal
+		sr:region_himalayas
+		sr:region_north_china
+		sr:region_manchuria
+		sr:region_east_siberia
+		sr:region_pacific_coast
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1894_sep = {
+	strategic_regions = {
+		sr:region_congo
+		sr:region_zanj
+		sr:region_ethiopia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1896_aug = {
+	strategic_regions = {
+		sr:region_baltic
+		sr:region_finland
+		sr:region_arctic_russia
+		sr:region_west_siberia
+		sr:region_east_siberia
+		sr:region_manchuria
+		sr:region_japan
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1897_feb = {
+	strategic_regions = {
+		sr:region_gran_colombia
+		sr:region_caribbean
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1897_jul = {
+	strategic_regions = {
+		sr:region_mexico
+		sr:region_caribbean
+		sr:region_brazil
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1898_jan = {
+	strategic_regions = {
+		sr:region_niger
+		sr:region_nile_basin
+		sr:region_zanj
+		sr:region_ethiopia
+		sr:region_bombay
+		sr:region_central_india
+		sr:region_himalayas
+		sr:region_north_china
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1900_may = {
+	strategic_regions = {
+		sr:region_mexico
+		sr:region_dixie
+		sr:region_iberia
+		sr:region_north_africa
+		sr:region_nile_basin
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1900_nov = {
+	strategic_regions = {
+		sr:region_congo
+		sr:region_zanj
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1901_may = {
+	strategic_regions = {
+		sr:region_zanj
+		sr:region_indonesia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1901_nov = {
+	strategic_regions = {
+		sr:region_italy
+		sr:region_north_africa
+		sr:region_nile_basin
+		sr:region_arabic
+		sr:region_madras
+		sr:region_indochina
+		sr:region_indonesia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1903_mar = {
+	strategic_regions = {
+		sr:region_central_asia
+		sr:region_north_china
+		sr:region_manchuria
+		sr:region_east_siberia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1904_mar = {
+	strategic_regions = {
+		sr:region_zanj
+		sr:region_indonesia
+		sr:region_indochina
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1904_sep = {
+	strategic_regions = {
+		sr:region_la_plata
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1905_mar = {
+	strategic_regions = {
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1905_aug = {
+	strategic_regions = {
+		sr:region_canada
+		sr:region_iberia
+		sr:region_north_africa
+		sr:region_nile_basin
+		sr:region_arabic
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1907_sep = {
+	strategic_regions = {
+		sr:region_caucasus
+		sr:region_central_asia
+		sr:region_himalayas
+		sr:region_north_africa
+		sr:region_manchuria
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1907_mar = {
+	strategic_regions = {
+		sr:region_andes
+		sr:region_brazil
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1908_jan = {
+	strategic_regions = {
+		sr:region_central_america
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1908_jun = {
+	strategic_regions = {
+		sr:region_mexico
+		sr:region_dixie
+		sr:region_senegal
+	}
+}
+
+verrier_geographic_region_solar_eclipse_hybrid_1908_dec = {
+	strategic_regions = {
+		sr:region_andes
+		sr:region_la_plata
+		sr:region_brazil
+	}
+}
+
+verrier_geographic_region_solar_eclipse_hybrid_1909_jun = {
+	strategic_regions = {
+		sr:region_north_sea_coast
+		sr:region_west_siberia
+		sr:region_central_asia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1910_may = {
+	strategic_regions = {
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1911_apr = {
+	strategic_regions = {
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1911_oct = {
+	strategic_regions = {
+		sr:region_central_asia
+		sr:region_himalayas
+		sr:region_south_china
+		sr:region_indochina
+		sr:region_indonesia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_hybrid_1912_apr = {
+	strategic_regions = {
+		sr:region_gran_colombia
+		sr:region_iberia
+		sr:region_france
+		sr:region_rhine
+		sr:region_north_germany
+		sr:region_baltic_states
+		sr:region_russia
+		sr:region_urals
+		sr:region_west_siberia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1912_oct = {
+	strategic_regions = {
+		sr:region_gran_colombia
+		sr:region_andes
+		sr:region_brazil
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1914_aug = {
+	strategic_regions = {
+		sr:region_baltic
+		sr:region_finland
+		sr:region_baltic_states
+		sr:region_belarus
+		sr:region_dnieper
+		sr:region_caucasus
+		sr:region_anatolia
+		sr:region_arabic
+		sr:region_persia
+		sr:region_bombay
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1915_feb = {
+	strategic_regions = {
+		sr:region_oceania
+		sr:region_indonesia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1916_feb = {
+	strategic_regions = {
+		sr:region_gran_colombia
+		sr:region_caribbean
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1916_jul = {
+	strategic_regions = {
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1918_jun = {
+	strategic_regions = {
+		sr:region_pacific_coast
+		sr:region_great_plains
+		sr:region_dixie
+		sr:region_caribbean
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1918_dec = {
+	strategic_regions = {
+		sr:region_la_plata
+		sr:region_brazil
+		sr:region_southern_africa
+		sr:region_congo
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1919_may = {
+	strategic_regions = {
+		sr:region_andes
+		sr:region_brazil
+		sr:region_senegal
+		sr:region_congo
+		sr:region_zanj
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1919_nov = {
+	strategic_regions = {
+		sr:region_dixie
+		sr:region_mexico
+		sr:region_caribbean
+		sr:region_gran_colombia
+		sr:region_senegal
+		sr:region_north_africa
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1921_apr = {
+	strategic_regions = {
+		sr:region_north_sea_coast
+		sr:region_england
+		sr:region_baltic
+		sr:region_finland
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1922_mar  = {
+	strategic_regions = {
+		sr:region_andes
+		sr:region_brazil
+		sr:region_senegal
+		sr:region_north_africa
+		sr:region_nile_basin
+		sr:region_arabic
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1922_sep = {
+	strategic_regions = {
+		sr:region_ethiopia
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1923_mar = {
+	strategic_regions = {
+		sr:region_la_plata
+		sr:region_southern_africa
+		sr:region_zanj
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1923_sep = {
+	strategic_regions = {
+		sr:region_pacific_coast
+		sr:region_mexico
+		sr:region_central_america
+		sr:region_caribbean
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1925_jan = {
+	strategic_regions = {
+		sr:region_the_midwest
+		sr:region_canada
+		sr:region_new_england
+		sr:region_north_sea_coast
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1926_jan = {
+	strategic_regions = {
+		sr:region_congo
+		sr:region_zanj
+		sr:region_indonesia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1927_jan = {
+	strategic_regions = {
+		sr:region_oceania
+		sr:region_la_plata
+		sr:region_brazil
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1927_jun = {
+	strategic_regions = {
+		sr:region_north_sea_coast
+		sr:region_england
+		sr:region_baltic
+		sr:region_east_siberia
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1929_may = {
+	strategic_regions = {
+		sr:region_indonesia
+		sr:region_indochina
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1929_nov = {
+	strategic_regions = {
+		sr:region_north_africa
+		sr:region_senegal
+		sr:region_congo
+		sr:region_zanj
+	}
+}
+
+verrier_geographic_region_solar_eclipse_hybrid_1930_apr = {
+	strategic_regions = {
+		sr:region_pacific_coast
+		sr:region_great_plains
+		sr:region_canada
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1930_oct = {
+	strategic_regions = {
+		sr:region_la_plata
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1932_mar = {
+	state_regions = {
+		STATE_TASMANIA
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1932_aug = {
+	strategic_regions = {
+		sr:region_canada
+		sr:region_new_england
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1933_feb = {
+	strategic_regions = {
+		sr:region_la_plata
+		sr:region_congo
+		sr:region_ethiopia
+	}
+	state_regions = {
+		STATE_EQUATORIA
+		STATE_YEMEN
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1933_aug = {
+	strategic_regions = {
+		sr:region_nile_basin
+		sr:region_arabic
+		sr:region_persia
+		sr:region_punjab
+		sr:region_central_india
+		sr:region_bengal
+		sr:region_indochina
+		sr:region_indonesia
+		sr:region_oceania
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1934_feb = {
+	state_regions = {
+		STATE_ACEH
+		STATE_TENASSERIM
+		STATE_STATE_MALAYA
+		STATE_NORTH_BORNEO
+		STATE_WEST_BORNEO
+		STATE_EAST_BORNEO
+		STATE_CELEBES
+		STATE_MOLUCCAS
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1934_aug = {
+	strategic_regions = {
+		sr:region_congo
+		sr:region_southern_africa
 	}
 }

--- a/common/geographic_regions/verrier_solar_eclipses_regions.txt
+++ b/common/geographic_regions/verrier_solar_eclipses_regions.txt
@@ -313,7 +313,6 @@ verrier_geographic_region_solar_eclipse_annular_1850_feb = {
 
 verrier_geographic_region_solar_eclipse_total_1850_aug = {
 	state_regions = {
-		STATE_WEST_MICRONESIA
 		STATE_EAST_MICRONESIA
 		STATE_HAWAIIAN_ISLANDS
 		STATE_CAJAMARCA
@@ -439,6 +438,7 @@ verrier_geographic_region_solar_eclipse_total_1856_apr = {
 		STATE_NORTHERN_TERRITORY
 		STATE_QUEENSLAND
 		STATE_KANAK
+		STATE_VANUATU
 	}
 }
 
@@ -1044,7 +1044,7 @@ verrier_geographic_region_solar_eclipse_total_1882_may = {
 		STATE_NIGER
 		STATE_WINDWARD_COAST
 		STATE_IVORY_COAST
-		STATE_GHANA
+		STATE_GOLD_COAST
 		STATE_DAHOMEY
 		STATE_TOGO
 		STATE_HAUSALAND
@@ -1098,15 +1098,16 @@ verrier_geographic_region_solar_eclipse_annular_1882_nov = {
 		STATE_EASTERN_NEW_GUINEA
 		STATE_WESTERN_NEW_GUINEA
 		STATE_KANAK
+		STATE_VANUATU
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1883_may = {
 	state_regions = {
 		STATE_NEW_SOUTH_WALES
-		STATE_EAST_MICRONESIA
-		STATE_WEST_MICRONESIA
+		STATE_FIIJ
 		STATE_TONGA
+		STATE_TAHITI
 		STATE_ICA
 	}
 }
@@ -1119,7 +1120,7 @@ verrier_geographic_region_solar_eclipse_annular_1883_oct = {
 		STATE_SARIWON
 		STATE_PYONGYANG
 		STATE_SEOUL
-		STATE_STATE_SOUTHERN_MANCHURIA
+		STATE_SOUTHERN_MANCHURIA
 		STATE_OUTER_MANCHURIA
 	}
 }
@@ -1148,8 +1149,7 @@ verrier_geographic_region_solar_eclipse_total_1885_sep = {
 verrier_geographic_region_solar_eclipse_annular_1886_mar = {
 	state_regions = {
 		STATE_BOUGAINVILLE
-		STATE_EAST_MICRONESIA
-		STATE_WEST_MICRONESIA
+		STATE_FIJI
 		STATE_TONGA
 		STATE_BAJIO
 		STATE_VERACRUZ
@@ -1185,13 +1185,15 @@ verrier_geographic_region_solar_eclipse_total_1886_aug = {
 }
 
 verrier_geographic_region_solar_eclipse_annular_1887_feb = {
-	strategic_regions = {
-		sr:region_andes
+	state_regions = {
+		STATE_TARAPACA
+		STATE_ANTOFAGASTA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1887_aug = {
 	strategic_regions = {
+		sr:region_rhine
 		sr:region_north_germany
 		sr:region_poland
 		sr:region_baltic_states
@@ -1203,44 +1205,110 @@ verrier_geographic_region_solar_eclipse_total_1887_aug = {
 		sr:region_manchuria
 		sr:region_japan
 	}
+	state_regions = {
+		STATE_ZEALAND
+		STATE_JUTLAND
+		STATE_GOTALAND
+		STATE_SCANIA
+		STATE_SLOVAKIA
+		STATE_KIEV
+		STATE_CHERNIHIV
+		STATE_KHARKOV
+		STATE_URGA
+		STATE_HINGGAN
+		STATE_BEIJING
+	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1889_jan = {
 	strategic_regions = {
 		sr:region_pacific_coast
 		sr:region_great_plains
-		sr:region_canada
+	}
+	state_regions = {
+		STATE_MANITOBA
+		STATE_MINNESOTA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1889_jun = {
-	strategic_regions = {
-		sr:region_southern_africa
-		sr:region_zanj
+	state_regions = {
+		STATE_NAMAQUALAND
+		STATE_HEREROLAND
+		STATE_BOTSWANA
+		STATE_ZAMBIA
+		STATE_ZAMBEZI
+		STATE_ZAMBEZIA
+		STATE_KAZEMBE
+		STATE_MOCAMBIQUE
+		STATE_LINDI
+		STATE_ZANZIBAR
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1889_dec = {
-	strategic_regions = {
-		sr:region_gran_colombia
-		sr:region_caribbean
-		sr:region_congo
-		sr:region_zanj
-		sr:region_ethiopia
+	state_regions = {
+		STATE_MIRANDA
+		STATE_BOLIVAR
+		STATE_WEST_INDIES
+		STATE_GUAYANA
+		STATE_CEARA
+		STATE_PARAIBA
+		STATE_RIO_GRANDE_DO_NORTE
+		STATE_NORTH_ANGOLA
+		STATE_BAS_CONGO
+		STATE_KASAI
+		STATE_EQUATEUR
+		STATE_CONGO_ORIENTALE
+		STATE_UGANDA
+		STATE_RIFT_VALLEY
+		STATE_KENYA
+		STATE_TANGANYIKA
+		STATE_EQUATORIA
+		STATE_AMHARA
+		STATE_OROMIA
+		STATE_SOMALILAND
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1890_jun = {
 	strategic_regions = {
-		sr:region_senegal
-		sr:region_north_africa
-		sr:region_balkans
 		sr:region_anatolia
 		sr:region_persia
 		sr:region_punjab
 		sr:region_central_india
 		sr:region_bengal
-		sr:region_indochina
+	}
+	state_regions = {
+		STATE_SENEGAL
+		STATE_GUINEA
+		STATE_INNER_MAURITANIA
+		STATE_MAURITANIA
+		STATE_WESTERN_MALI
+		STATE_TIMBUKTU
+		STATE_SAHARA
+		STATE_EAST_SAHARA
+		STATE_TRIPOLI
+		STATE_LIBYA
+		STATE_PELOPONNESE
+		STATE_CRETE
+		STATE_SYRIA
+		STATE_ALEPPO
+		STATE_DEIR_EZ_ZOR
+		STATE_MOSUL
+		STATE_HIMALAYAS
+		STATE_CHIANG_MAI
+		STATE_LAOS
+		STATE_SHAN_STATES
+		STATE_MANDALAY
+		STATE_ARAKAN
+		STATE_KACHIN
+	}
+}
+
+verrier_geographic_region_solar_eclipse_hybrid_1890_dec = {
+	state_regions = {
+		STATE_NORTH_MADAGASCAR
 	}
 }
 
@@ -1250,19 +1318,42 @@ verrier_geographic_region_solar_eclipse_annular_1891_jun = {
 	}
 }
 
+verrier_geographic_region_solar_eclipse_total_1892_apr = {
+	state_regions = {
+		STATE_LOS_RIOS
+	}
+}
+
 verrier_geographic_region_solar_eclipse_total_1893_apr = {
-	strategic_regions = {
-		sr:region_la_plata
-		sr:region_brazil
-		sr:region_senegal
-		sr:region_niger
-		sr:region_nile_basin
+	state_regions = {
+		STATE_SANTIAGO
+		STATE_TUCUMAN
+		STATE_JUJUY
+		STATE_CHACO
+		STATE_ALTO_PARAGUAY
+		STATE_MATO_GROSSO
+		STATE_GOIAS
+		STATE_MARANHAO
+		STATE_PIAUI
+		STATE_SENEGAL
+		STATE_MAURITANIA
+		STATE_INNER_MAURITANIA
+		STATE_WESTERN_MALI
+		STATE_EASTERN_MALI
+		STATE_TIMBUKTU
+		STATE_NIGER
+		STATE_CHAD
+		STATE_DARFUR
+		STATE_KORDOFAN
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1893_oct = {
-	strategic_regions = {
-		sr:region_andes
+	state_regions = {
+		STATE_ICA
+		STATE_LIMA
+		STATE_LA_PAZ
+		STATE_ACRE
 	}
 }
 
@@ -1271,193 +1362,377 @@ verrier_geographic_region_solar_eclipse_hybrid_1894_apr = {
 		sr:region_madras
 		sr:region_bengal
 		sr:region_himalayas
-		sr:region_north_china
-		sr:region_manchuria
-		sr:region_east_siberia
-		sr:region_pacific_coast
+	}
+	state_regions = {
+		STATE_KACHIN
+		STATE_ALXA
+		STATE_URGA
+		STATE_HINGGAN
+		STATE_NORTHERN_MANCHURIA
+		STATE_AMUR
+		STATE_OKHOTSK
+		STATE_CHUKOTKA
+		STATE_KAMCHATKA
+		STATE_ALASKA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1894_sep = {
-	strategic_regions = {
-		sr:region_congo
-		sr:region_zanj
-		sr:region_ethiopia
+	state_regions = {
+		STATE_CONGO_ORIENTALE
+		STATE_UGANDA
+		STATE_RIFT_VALLEY
+		STATE_KENYA
+		STATE_SOMALILAND
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1896_aug = {
 	strategic_regions = {
-		sr:region_baltic
-		sr:region_finland
 		sr:region_arctic_russia
-		sr:region_west_siberia
 		sr:region_east_siberia
-		sr:region_manchuria
-		sr:region_japan
+	}
+	state_regions = {
+		STATE_NORTHERN_NORWAY
+		STATE_NORRLAND
+		STATE_OULU
+		STATE_KOLA
+		STATE_AMUR
+		STATE_OUTER_MANCHURIA
+		STATE_HOKKAIDO
+		STATE_SAKHALIN
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1897_feb = {
 	strategic_regions = {
 		sr:region_gran_colombia
-		sr:region_caribbean
+	}
+	state_regions = {
+		STATE_NORTH_ISLAND
+		STATE_TONGA
+		STATE_WEST_INDIES
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1897_jul = {
 	strategic_regions = {
-		sr:region_mexico
 		sr:region_caribbean
-		sr:region_brazil
+	}
+	state_regions = {
+		STATE_JALISCO
+		STATE_SINALOA
+		STATE_ZACATECAS
+		STATE_BAJIO
+		STATE_DURANGO
+		STATE_RIO_GRANDE
+		STATE_CEARA
+		STATE_PARAIBA
+		STATE_RIO_GRANDE_DO_NORTE
+		STATE_PERNAMBUCO
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1898_jan = {
 	strategic_regions = {
 		sr:region_niger
-		sr:region_nile_basin
-		sr:region_zanj
-		sr:region_ethiopia
 		sr:region_bombay
 		sr:region_central_india
 		sr:region_himalayas
-		sr:region_north_china
+	}
+	state_regions = {
+		STATE_UBANGI_SHARI
+		STATE_EQUATEUR
+		STATE_UGANDA
+		STATE_RIFT_VALLEY
+		STATE_KENYA
+		STATE_SOMALILAND
+		STATE_OROMIA
+		STATE_AMHARA
+		STATE_NINGXIA
+		STATE_GANSU
+		STATE_ALXA
+		STATE_HINGGAN
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1900_may = {
 	strategic_regions = {
-		sr:region_mexico
 		sr:region_dixie
+		sr:region_new_england
 		sr:region_iberia
-		sr:region_north_africa
-		sr:region_nile_basin
+	}
+	state_regions = {
+		STATE_RIO_GRANDE
+		STATE_JALISCO
+		STATE_BAJIO
+		STATE_ZACATECAS
+		STATE_DURANGO
+		STATE_CHIHUAHUA
+		STATE_SINALOA
+		STATE_AL_RIF
+		STATE_CONSTANTINE
+		STATE_ORAN
+		STATE_ALGIERS
+		STATE_TUNISIA
+		STATE_TRIPOLI
+		STATE_LIBYA
+		STATE_LIBYAN_DESERT
+		STATE_EGYPTIAN_DESERT
+		STATE_MATRUH
+		STATE_SINAI
+		STATE_UPPER_EGYPT
+		STATE_MIDDLE_EGYPT
+		STATE_LOWER_EGYPT
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1900_nov = {
-	strategic_regions = {
-		sr:region_congo
-		sr:region_zanj
-		sr:region_oceania
+	state_regions = {
+		STATE_NORTH_ANGOLA
+		STATE_SOUTH_ANGOLA
+		STATE_EAST_ANGOLA
+		STATE_ZAMBIA
+		STATE_ZAMBEZI
+		STATE_LOURENCO_MARQUES
+		STATE_SOUTH_MADAGASCAR
+		STATE_ZAMBEZIA
+		STATE_WESTERN_AUSTRALIA
+		STATE_NORTHERN_TERRITORY
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1901_may = {
 	strategic_regions = {
-		sr:region_zanj
 		sr:region_indonesia
+	}
+	state_regions = {
+		STATE_ZULULAND
+		STATE_SOUTH_MADAGASCAR
+		STATE_MALAYA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1901_nov = {
-	strategic_regions = {
-		sr:region_italy
-		sr:region_north_africa
-		sr:region_nile_basin
-		sr:region_arabic
-		sr:region_madras
-		sr:region_indochina
-		sr:region_indonesia
+	state_regions = {
+		STATE_SICILY
+		STATE_MALTA
+		STATE_LIBYA
+		STATE_CRETE
+		STATE_MATRUH
+		STATE_UPPER_EGYPT
+		STATE_MIDDLE_EGYPT
+		STATE_LOWER_EGYPT
+		STATE_SINAI
+		STATE_TRANSJORDAN
+		STATE_PALESTINE
+		STATE_HEDJAZ
+		STATE_HAIL
+		STATE_NEJD
+		STATE_YEMEN
+		STATE_OMAN
+		STATE_CEYLON
+		STATE_MYSORE
+		STATE_TRAVANCORE
+		STATE_MADRAS
+		STATE_PEGU
+		STATE_TENASSERIM
+		STATE_NAKHON_RATCHASIMA
+		STATE_CAMBODIA
+		STATE_MEKONG
+		STATE_LAOS
+		STATE_ANNAM
+		STATE_LUZON
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1903_mar = {
-	strategic_regions = {
-		sr:region_central_asia
-		sr:region_north_china
-		sr:region_manchuria
-		sr:region_east_siberia
+	state_regions = {
+		STATE_KIRGHIZIA
+		STATE_FERGANA
+		STATE_TABRIZ
+		STATE_TIANSHAN
+		STATE_DZUNGARIA
+		STATE_QINGHAI
+		STATE_GANSU
+		STATE_ALXA
+		STATE_ULIASTAI
+		STATE_URGA
+		STATE_NORTHERN_MANCHURIA
+		STATE_AMUR
+		STATE_TRANS_BAIKAL
+		STATE_OKHOTSK
+		STATE_CHUKOTKA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1904_mar = {
-	strategic_regions = {
-		sr:region_zanj
-		sr:region_indonesia
-		sr:region_indochina
+	state_regions = {
+		STATE_ZANZIBAR
+		STATE_LINDI
+		STATE_MOCAMBIQUE
+		STATE_TENASSERIM
+		STATE_NAKHON_RATCHASIMA
+		STATE_CAMBODIA
+		STATE_LAOS
+		STATE_MEKONG
+		STATE_ANNAM
+		STATE_LUZON
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1904_sep = {
-	strategic_regions = {
-		sr:region_la_plata
+	state_regions = {
+		STATE_TONGA
+		STATE_TAHITI
+		STATE_ANTOFAGASTA
+		STATE_SANTIAGO
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1905_mar = {
-	strategic_regions = {
-		sr:region_oceania
+	state_regions = {
+		STATE_WESTERN_AUSTRALIA
+		STATE_SOUTH_AUSTRALIA
+		STATE_NORTHERN_TERRITORY
+		STATE_QUEENSLAND
+		STATE_KANAK
+		STATE_VANUATU
+		STATE_FIJI
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1905_aug = {
 	strategic_regions = {
 		sr:region_canada
+		sr:region_occitania
 		sr:region_iberia
-		sr:region_north_africa
-		sr:region_nile_basin
-		sr:region_arabic
+	}
+	state_regions = {
+		STATE_SICILY
+		STATE_SARDINIA
+		STATE_CONSTANTINE
+		STATE_ALGIERS
+		STATE_ORAN
+		STATE_TRIPOLI
+		STATE_LIBYA
+		STATE_LIBYAN_DESERT
+		STATE_DONGOLA
+		STATE_UPPER_EGYPT
+		STATE_MIDDLE_EGYPT
+		STATE_LOWER_EGYPT
+		STATE_EGYPTIAN_DESERT
+		STATE_MATRUH
+		STATE_SINAI
+		STATE_HEDJAZ
+		STATE_NEJD
+		STATE_YEMEN
+		STATE_OMAN
+		STATE_ABU_DHABI
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1907_sep = {
 	strategic_regions = {
-		sr:region_caucasus
 		sr:region_central_asia
 		sr:region_himalayas
-		sr:region_north_africa
-		sr:region_manchuria
+	}
+	state_regions = {
+		STATE_ASTRAKHAN
+		STATE_TARTARIA
+		STATE_KABUL
+		STATE_KASHMIR
+		STATE_ALXA
+		STATE_GANSU
+		STATE_ULIASTAI
+		STATE_URGA
+		STATE_NORTHERN_MANCHURIA
+		STATE_AMUR
+		STATE_TRANS_BAIKAL
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1907_mar = {
-	strategic_regions = {
-		sr:region_andes
-		sr:region_brazil
+	state_regions = {
+		STATE_ANTOFAGASTA
+		STATE_POTOSI
+		STATE_SANTA_CRUZ
+		STATE_JUJUY
+		STATE_MATO_GROSSO
+		STATE_MINAS_GERAIS
+		STATE_GOIAS
+		STATE_BAHIA
+		STATE_RIO_DE_JANEIRO
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1908_jan = {
-	strategic_regions = {
-		sr:region_central_america
+	state_regions = {
+		STATE_TONGA
+		STATE_COSTA_RICA
+		STATE_NICARAGUA
+		STATE_PANAMA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1908_jun = {
 	strategic_regions = {
-		sr:region_mexico
-		sr:region_dixie
 		sr:region_senegal
+	}
+	state_regions = {
+		STATE_BAJIO
+		STATE_VERACRUZ
+		STATE_MEXICO
+		STATE_OAXACA
+		STATE_GUERRERO
+		STATE_JALISCO
+		STATE_YUCATAN
+		STATE_FLORIDA
+		STATE_BERMUDA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_hybrid_1908_dec = {
-	strategic_regions = {
-		sr:region_andes
-		sr:region_la_plata
-		sr:region_brazil
+	state_regions = {
+		STATE_ANTOFAGASTA
+		STATE_JUJUY
+		STATE_TUCUMAN
+		STATE_CHACO
+		STATE_SANTA_FE
+		STATE_CORRIENTES
+		STATE_URUGUAY
+		STATE_RIO_GRANDE_DO_SUL
 	}
 }
 
 verrier_geographic_region_solar_eclipse_hybrid_1909_jun = {
-	strategic_regions = {
-		sr:region_north_sea_coast
-		sr:region_west_siberia
-		sr:region_central_asia
+	state_regions = {
+		STATE_SEMIRECHE
+		STATE_TOMSK
+		STATE_UPPER_YENISEYSK
+		STATE_NUNAVUT
+		STATE_GREENLAND
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1910_may = {
-	strategic_regions = {
-		sr:region_oceania
+	state_regions = {
+		STATE_TASMANIA
+		STATE_VICTORIA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1911_apr = {
-	strategic_regions = {
-		sr:region_oceania
+	state_regions = {
+		STATE_NEW_SOUTH_WALES
+		STATE_FIJI
+		STATE_EAST_MICRONESIA
+		STATE_TONGA
+		STATE_SAN_SALVADOR
+		STATE_HONDURAS
+		STATE_NICARAGUA
+		STATE_COSTA_RICA
+		STATE_PANAMA
 	}
 }
 
@@ -1465,17 +1740,30 @@ verrier_geographic_region_solar_eclipse_annular_1911_oct = {
 	strategic_regions = {
 		sr:region_central_asia
 		sr:region_himalayas
-		sr:region_south_china
-		sr:region_indochina
-		sr:region_indonesia
+	}
+	state_regions = {
+		STATE_SICHUAN
+		STATE_YUNNAN
+		STATE_GUIZHOU
+		STATE_GUANGXI
+		STATE_GUANGDONG
+		STATE_TONKIN
+		STATE_LUZON
+		STATE_MINDANAO
+		STATE_CELEBES
+		STATE_MOLUCCAS
+		STATE_WESTERN_NEW_GUINEA
+		STATE_EASTERN_NEW_GUINEA
+		STATE_SOLOMON_ISLANDS
 	}
 }
 
 verrier_geographic_region_solar_eclipse_hybrid_1912_apr = {
 	strategic_regions = {
-		sr:region_gran_colombia
 		sr:region_iberia
+		sr:region_occitania
 		sr:region_france
+		sr:region_england
 		sr:region_rhine
 		sr:region_north_germany
 		sr:region_baltic_states
@@ -1483,13 +1771,32 @@ verrier_geographic_region_solar_eclipse_hybrid_1912_apr = {
 		sr:region_urals
 		sr:region_west_siberia
 	}
+	state_regions = {
+		STATE_BOLIVAR
+		STATE_GUAYANA
+		STATE_CANARY_ISLANDS
+		STATE_MADEIRA
+		STATE_JUTLAND
+		STATE_ZEALAND
+		STATE_SCANIA
+		STATE_GOTALAND
+		STATE_GOTLAND
+		STATE_UUSIMAA
+		STATE_KUOPIO
+		STATE_WEST_KARELIA
+	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1912_oct = {
-	strategic_regions = {
-		sr:region_gran_colombia
-		sr:region_andes
-		sr:region_brazil
+	state_regions = {
+		STATE_GUAVIARE
+		STATE_CAUCA
+		STATE_ECUADOR
+		STATE_PASTAZA
+		STATE_AMAZONAS
+		STATE_MATO_GROSSO
+		STATE_SAO_PAULO
+		STATE_SANTA_CATARINA
 	}
 }
 
@@ -1498,6 +1805,7 @@ verrier_geographic_region_solar_eclipse_total_1914_aug = {
 		sr:region_baltic
 		sr:region_finland
 		sr:region_baltic_states
+		sr:region_poland
 		sr:region_belarus
 		sr:region_dnieper
 		sr:region_caucasus
@@ -1506,133 +1814,312 @@ verrier_geographic_region_solar_eclipse_total_1914_aug = {
 		sr:region_persia
 		sr:region_bombay
 	}
+	state_regions = {
+		STATE_NUNAVUT
+		STATE_GREENLAND
+	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1915_feb = {
-	strategic_regions = {
-		sr:region_oceania
-		sr:region_indonesia
+	state_regions = {
+		STATE_WESTERN_AUSTRALIA
+		STATE_NORTHERN_TERRITORY
+		STATE_EASTERN_NEW_GUINEA
+		STATE_WESTERN_NEW_GUINEA
+		STATE_WEST_MICRONESIA
+		STATE_EAST_MICRONESIA
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1915_aug = {
+	state_regions = {
+		STATE_FORMOSA
+		STATE_RYUKYU_ISLANDS
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1916_feb = {
 	strategic_regions = {
-		sr:region_gran_colombia
-		sr:region_caribbean
+		sr:region_england
+	}
+	state_regions = {
+		STATE_CAUCA
+		STATE_ANTIOQUIA
+		STATE_CUNDINAMARCA
+		STATE_ZULIA
+		STATE_MIRANDA
+		STATE_WEST_INDIES
+		STATE_PUERTO_RICO
+		STATE_ULSTER
+		STATE_MUNSTER
+		STATE_LEINSTER
+		STATE_CONNAUGHT
+		STATE_BRITTANY
+		STATE_LOWLANDS
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1916_jul = {
-	strategic_regions = {
-		sr:region_oceania
+	state_regions = {
+		STATE_WESTERN_AUSTRALIA
+		STATE_SOUTH_AUSTRALIA
+		STATE_VICTORIA
+		STATE_TASMANIA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1918_jun = {
 	strategic_regions = {
-		sr:region_pacific_coast
-		sr:region_great_plains
 		sr:region_dixie
-		sr:region_caribbean
+	}
+	state_regions = {
+		STATE_WASHINGTON
+		STATE_OREGON
+		STATE_IDAHO
+		STATE_UTAH
+		STATE_WYOMING
+		STATE_COLORADO
+		STATE_NEW_MEXICO
+		STATE_BAHAMAS
+		STATE_WESTERN_CUBA
+		STATE_CENTRAL_CUBA
+		STATE_EASTERN_CUBA
+		STATE_HAITI
+		STATE_SANTO_DOMINGO
+		STATE_PUERTO_RICO
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1918_dec = {
-	strategic_regions = {
-		sr:region_la_plata
-		sr:region_brazil
-		sr:region_southern_africa
-		sr:region_congo
+	state_regions = {
+		STATE_SANTIAGO
+		STATE_TUCUMAN
+		STATE_RIO_NEGRO
+		STATE_LA_PAMPA
+		STATE_BUENOS_AIRES
+		STATE_URUGUAY
+		STATE_HEREROLAND
+		STATE_SOUTH_ANGOLA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1919_may = {
-	strategic_regions = {
-		sr:region_andes
-		sr:region_brazil
-		sr:region_senegal
-		sr:region_congo
-		sr:region_zanj
+	state_regions = {
+		STATE_ANTOFAGASTA
+		STATE_LA_PAZ
+		STATE_TARAPACA
+		STATE_SANTA_CRUZ
+		STATE_POTOSI
+		STATE_MATO_GROSSO
+		STATE_GOIAS
+		STATE_MARANHAO
+		STATE_PIAUI
+		STATE_CEARA
+		STATE_SIERRA_LEONE
+		STATE_LIBERIA
+		STATE_WINDWARD_COAST
+		STATE_IVORY_COAST
+		STATE_GOLD_COAST
+		STATE_SOUTH_CAMEROON
+		STATE_GABON
+		STATE_CONGO
+		STATE_BAS_CONGO
+		STATE_EQUATEUR
+		STATE_KASAI
+		STATE_KATANGA
+		STATE_KAZEMBE
+		STATE_LINDI
+		STATE_ZANZIBAR
+		STATE_MOCAMBIQUE
+		STATE_NORTH_MADAGASCAR
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1919_nov = {
 	strategic_regions = {
-		sr:region_dixie
-		sr:region_mexico
 		sr:region_caribbean
-		sr:region_gran_colombia
 		sr:region_senegal
 		sr:region_north_africa
+	}
+	state_regions = {
+		STATE_TEXAS
+		STATE_RIO_GRANDE
+		STATE_SENEGAL
+		STATE_GUINEA
+		STATE_WESTERN_MALI
+		STATE_EASTERN_MALI
+		STATE_INNER_MAURITANIA
+		STATE_TIMBUKTU
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1921_apr = {
 	strategic_regions = {
-		sr:region_north_sea_coast
 		sr:region_england
 		sr:region_baltic
-		sr:region_finland
+	}
+	state_regions = {
+		STATE_ICELAND
+		STATE_ULSTER
+		STATE_LEINSTER
+		STATE_CONNAUGHT
+		STATE_MUNSTER
+		STATE_LOWLANDS
+		STATE_HIGHLANDS
+		STATE_UUSIMAA
+		STATE_OSTROBOTHNIA
+		STATE_OULU
+		STATE_KOLA
+	}
+}
+
+verrier_geographic_region_solar_eclipse_total_1921_oct = {
+	state_regions = {
+		STATE_ARAUCANIA
+		STATE_PATAGONIA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1922_mar  = {
-	strategic_regions = {
-		sr:region_andes
-		sr:region_brazil
-		sr:region_senegal
-		sr:region_north_africa
-		sr:region_nile_basin
-		sr:region_arabic
+	state_regions = {
+		STATE_ICA
+		STATE_LIMA
+		STATE_ACRE
+		STATE_AMAZONAS
+		STATE_PARA
+		STATE_MARANHAO
+		STATE_SENEGAL
+		STATE_WESTERN_MALI
+		STATE_MAURITANIA
+		STATE_INNER_MAURITANIA
+		STATE_TIMBUKTU
+		STATE_EAST_SAHARA
+		STATE_TRIPOLI
+		STATE_LIBYA
+		STATE_EGYPTIAN_DESERT
+		STATE_MATRUH
+		STATE_UPPER_EGYPT
+		STATE_MIDDLE_EGYPT
+		STATE_LOWER_EGYPT
+		STATE_SINAI
+		STATE_HEDJAZ
+		STATE_HAIL
+		STATE_BASRA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1922_sep = {
-	strategic_regions = {
-		sr:region_ethiopia
-		sr:region_oceania
+	state_regions = {
+		STATE_KENYA
+		STATE_SOMALILAND
+		STATE_OROMIA
+		STATE_WEST_JAVA
+		STATE_CENTRAL_JAVA
+		STATE_WESTERN_AUSTRALIA
+		STATE_NORTHERN_TERRITORY
+		STATE_SOUTH_AUSTRALIA
+		STATE_QUEENSLAND
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1923_mar = {
-	strategic_regions = {
-		sr:region_la_plata
-		sr:region_southern_africa
-		sr:region_zanj
+	state_regions = {
+		STATE_ARAUCANIA
+		STATE_PATAGONIA
+		STATE_SOUTH_ATLANTIC_ISLANDS
+		STATE_NAMAQUALAND
+		STATE_HEREROLAND
+		STATE_BOTSWANA
+		STATE_ZAMBEZI
+		STATE_ZAMBEZIA
+		STATE_MOCAMBIQUE
+		STATE_NORTH_MADAGASCAR
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1923_sep = {
 	strategic_regions = {
-		sr:region_pacific_coast
 		sr:region_mexico
-		sr:region_central_america
 		sr:region_caribbean
+	}
+	state_regions = {
+		STATE_CALIFORNIA
+		STATE_GUATEMALA
+		STATE_HONDURAS
+		STATE_SAN_SALVADOR
+		STATE_NICARAGUA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1925_jan = {
 	strategic_regions = {
 		sr:region_the_midwest
-		sr:region_canada
 		sr:region_new_england
-		sr:region_north_sea_coast
+	}
+	state_regions = {
+		STATE_MANITOBA
+		STATE_ONTARIO
+		STATE_NEW_BRUNSWICK
+		STATE_ICELAND
+		STATE_LOWLANDS
+		STATE_HIGHLANDS
+		STATE_ULSTER
+		STATE_CONNAUGHT
+		STATE_MUNSTER
+		STATE_LEINSTER
+		STATE_YORKSHIRE
+		STATE_LANCASHIRE
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1925_jul = {
+	state_regions = {
+		STATE_FIJI
+		STATE_TONGA
+		STATE_TAHITI
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1926_jan = {
-	strategic_regions = {
-		sr:region_congo
-		sr:region_zanj
-		sr:region_indonesia
+	state_regions = {
+		STATE_UBANGI_SHARI
+		STATE_EQUATORIA
+		STATE_EQUATEUR
+		STATE_CONGO_ORIENTALE
+		STATE_UGANDA
+		STATE_RIFT_VALLEY
+		STATE_KENYA
+		STATE_SOMALILAND
+		STATE_SOUTH_SUMATRA
+		STATE_NORTH_BORNEO
+		STATE_EAST_BORNEO
+		STATE_WEST_BORNEO
+		STATE_VISAYAS
+		STATE_MINDANAO
+	}
+}
+
+verrier_geographic_region_solar_eclipse_annular_1926_jul = {
+	state_regions = {
+		STATE_WEST_MICRONESIA
+		STATE_EAST_MICRONESIA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1927_jan = {
-	strategic_regions = {
-		sr:region_oceania
-		sr:region_la_plata
-		sr:region_brazil
+	state_regions = {
+		STATE_NORTH_ISLAND
+		STATE_ARAUCANIA
+		STATE_LOS_RIOS
+		STATE_PATAGONIA
+		STATE_RIO_NEGRO
+		STATE_CORRIENTES
+		STATE_SANTA_FE
+		STATE_BUENOS_AIRES
+		STATE_URUGUAY
+		STATE_RIO_GRANDE_DO_SUL
+		STATE_SANTA_CATARINA
+		STATE_PARANA
 	}
 }
 
@@ -1640,38 +2127,84 @@ verrier_geographic_region_solar_eclipse_total_1927_jun = {
 	strategic_regions = {
 		sr:region_north_sea_coast
 		sr:region_england
+		sr:region_france
+		sr:region_rhine
+		sr:region_north_germany
 		sr:region_baltic
-		sr:region_east_siberia
+	}
+	state_regions = {
+		STATE_WEST_PRUSSIA
+		STATE_EAST_PRUSSIA
+		STATE_TARTU
+		STATE_TALINN
+		STATE_KOLYMA
+		STATE_CHUKOTKA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1929_may = {
-	strategic_regions = {
-		sr:region_indonesia
-		sr:region_indochina
+	state_regions = {
+		STATE_ACEH
+		STATE_TENASSERIM
+		STATE_CAMBODIA
+		STATE_MEKONG
+		STATE_LUZON
+		STATE_VISAYAS
+		STATE_MINDANAO
+		STATE_WEST_MICRONESIA
+		STATE_EAST_MICRONESIA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1929_nov = {
-	strategic_regions = {
-		sr:region_north_africa
-		sr:region_senegal
-		sr:region_congo
-		sr:region_zanj
+	state_regions = {
+		STATE_NEW_BRUNSWICK
+		STATE_WEST_SAHARA
+		STATE_INNER_MAURITANIA
+		STATE_WESTERN_MALI
+		STATE_EASTERN_MALI
+		STATE_VOLTA
+		STATE_TOGO
+		STATE_GOLD_COAST
+		STATE_IVORY_COAST
+		STATE_DAHOMEY
+		STATE_YORUBA_STATES
+		STATE_BENIN
+		STATE_NIGER_DELTA
+		STATE_GABON
+		STATE_CONGO
+		STATE_EQUATEUR
+		STATE_BAS_CONGO
+		STATE_KASAI
+		STATE_CONGO_ORIENTALE
+		STATE_TANGANYIKA
+		STATE_LINDI
+		STATE_ZANZIBAR
 	}
 }
 
 verrier_geographic_region_solar_eclipse_hybrid_1930_apr = {
-	strategic_regions = {
-		sr:region_pacific_coast
-		sr:region_great_plains
-		sr:region_canada
+	state_regions = {
+		STATE_CALIFORNIA
+		STATE_NEVADA
+		STATE_IDAHO
+		STATE_OREGON
+		STATE_WASHINGTON
+		STATE_MONTANA
+		STATE_SASKATCHEWAN
+		STATE_MANITOBA
+		STATE_ONTARIO
+		STATE_QUEBEC
+		STATE_NEWFOUNDLAND
 	}
 }
 
 verrier_geographic_region_solar_eclipse_total_1930_oct = {
-	strategic_regions = {
-		sr:region_la_plata
+	state_regions = {
+		STATE_EAST_MICRONESIA
+		STATE_FIJI
+		STATE_ARAUCANIA
+		STATE_PATAGONIA
 	}
 }
 
@@ -1686,31 +2219,73 @@ verrier_geographic_region_solar_eclipse_total_1932_aug = {
 		sr:region_canada
 		sr:region_new_england
 	}
+	state_regions = {
+		STATE_BERMUDA
+	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1933_feb = {
-	strategic_regions = {
-		sr:region_la_plata
-		sr:region_congo
-		sr:region_ethiopia
-	}
 	state_regions = {
+		STATE_LOS_RIOS
+		STATE_PATAGONIA
+		STATE_BAS_CONGO
+		STATE_CONGO
+		STATE_GABON
+		STATE_EQUATEUR
+		STATE_CONGO_ORIENTALE
+		STATE_UBANGI_SHARI
 		STATE_EQUATORIA
+		STATE_BLUE_NILE
+		STATE_AMHARA
+		STATE_GONDER
+		STATE_ERITREA
 		STATE_YEMEN
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1933_aug = {
 	strategic_regions = {
-		sr:region_nile_basin
-		sr:region_arabic
-		sr:region_persia
 		sr:region_punjab
 		sr:region_central_india
 		sr:region_bengal
-		sr:region_indochina
-		sr:region_indonesia
-		sr:region_oceania
+	}
+	state_regions = {
+		STATE_LIBYA
+		STATE_MATRUH
+		STATE_LOWER_EGYPT
+		STATE_SINAI
+		STATE_PALESTINE
+		STATE_LEBANON
+		STATE_SYRIA
+		STATE_ALEPPO
+		STATE_TRANSJORDAN
+		STATE_DEIR_EZ_ZOR
+		STATE_MOSUL
+		STATE_BAGHDAD
+		STATE_BASRA
+		STATE_LURISTAN
+		STATE_KHUZESTAN
+		STATE_IRAKAJEMI
+		STATE_ISFAHAN
+		STATE_KERMAN
+		STATE_KHORASAN
+		STATE_HERAT
+		STATE_KANDAHAR
+		STATE_CENTRAL_HIGHLANDS
+		STATE_KABUL
+		STATE_HIMALAYAS
+		STATE_ARAKAN
+		STATE_MANDALAY
+		STATE_PEGU
+		STATE_TENASSERIM
+		STATE_BANGKOK
+		STATE_MALAYA
+		STATE_NORTH_BORNEO
+		STATE_EAST_BORNEO
+		STATE_WEST_BORNEO
+		STATE_SUNDA_ISLANDS
+		STATE_NORTHERN_TERRITORY
+		STATE_QUEENSLAND
 	}
 }
 
@@ -1724,12 +2299,20 @@ verrier_geographic_region_solar_eclipse_total_1934_feb = {
 		STATE_EAST_BORNEO
 		STATE_CELEBES
 		STATE_MOLUCCAS
+		STATE_WEST_MICRONESIA
+		STATE_EAST_MICRONESIA
 	}
 }
 
 verrier_geographic_region_solar_eclipse_annular_1934_aug = {
-	strategic_regions = {
-		sr:region_congo
-		sr:region_southern_africa
+	state_regions = {
+		STATE_SOUTH_ANGOLA
+		STATE_EAST_ANGOLA
+		STATE_ZAMBIA
+		STATE_HEREROLAND
+		STATE_BOTSWANA
+		STATE_ZAMBEZI
+		STATE_TRANSVAAL
+		STATE_LOURENCO_MARQUES
 	}
 }

--- a/common/on_actions/mr_science_verrier_on_actions.txt
+++ b/common/on_actions/mr_science_verrier_on_actions.txt
@@ -1808,6 +1808,1021 @@ verrier_on_yearly_pulse_solar_eclipses = {
 				}
 			}
 		}
+		else_if = {
+			limit = {
+				year = 1889
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1889_jan
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					#days = 0 #Jan 1st
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1889_jun
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 178 #Jun 28th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1889_dec
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 355 #Dec 22nd
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1890
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1890_jun
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 167 #Jun 17th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1891
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1890_jun
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 156 #Jun 6th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1893
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1893_apr
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 105 #Apr 16th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1893_oct
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 281 #Oct 9th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1894
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1894_apr
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 95 #Apr 6th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1894_sep
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 271 #Sep 29th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1896
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1896_aug
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 221 #Aug 9th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1897
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1897_feb
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 31 #Feb 1st
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1897_jul
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 209 #Jul 29th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1898
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1898_jan
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 21 #Jan 22nd
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1900
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1900_may
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 147 #May 28th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1900_nov
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 325 #Nov 22nd
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1901
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1901_may
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 137 #May 18th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1901_nov
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 314 #Nov 11th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1903
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1903_mar
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 87 #Mar 29th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1904
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1904_mar
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 76 #Mar 17th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1904_sep
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 252 #Sep 9th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1905
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1905_mar
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 64 #Mar 6th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1905_aug
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 241 #Aug 30th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1907
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1907_sep
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 13 #Jan 14th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1907_mar
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 190 #Jul 10th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1908
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1908_jan
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 2 #Jan 3rd
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1908_jun
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 179 #Jun 28th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1908_dec
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 357 #Dec 23rd
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1909
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1909_jun
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 167 #Jun 17th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1910
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1910_may
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 128 #May 9th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1911
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1911_apr
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 117 #Apr 28th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1911_oct
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 294 #Oct 22nd
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1912
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1912_apr
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 107 #Apr 17th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1912_oct
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 283 #Oct 10th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1914
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1914_aug
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 232 #Aug 21st
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1915
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1915_feb
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 44 #Feb 14th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1916
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1916_feb
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 33 #Feb 3rd
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1916_jul
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 211 #Jul 30th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1918
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1918_jun
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 158 #Jun 8th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1918_dec
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 336 #Dec 3rd
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1919
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1919_may
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 148 #May 29th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1919_nov
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 325 #Nov 22nd
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1921
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1921_apr
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 97 #Apr 8th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1922
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1922_mar
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 83 #Mar 28th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1922_sep
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 263 #Sep 21st
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1923
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1923_mar
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 75 #Mar 17th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1923_sep
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 252 #Sep 10th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1925
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1925_jan
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 23 #Jan 24th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1926
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1926_jan
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 13 #Jan 14th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1927
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1927_jan
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 2 #Jan 3rd
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1927_jun
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 179 #Jun 29th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1929
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1929_may
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 128 #May 9th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1929_nov
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 304 #Nov 1st
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1930
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1930_apr
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 117 #Apr 28th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1930_oct
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 293 #Oct 21st
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1932
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1932_mar
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 66 #Mar 7th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1932_aug
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 243 #Aug 31st
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1933
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1933_feb
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 54 #Feb 24th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1933_aug
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 232 #Aug 21st
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1934
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1934_feb
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 44 #Feb 14th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1934_aug
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 221 #Aug 10th
+				}
+			}
+		}
 	}
 }
 

--- a/common/on_actions/mr_science_verrier_on_actions.txt
+++ b/common/on_actions/mr_science_verrier_on_actions.txt
@@ -26,6 +26,7 @@ on_yearly_pulse = {
 	on_actions = {
 		#No delay as it does not work in this on action
 		verrier_on_yearly_pulse
+		verrier_on_yearly_pulse_solar_eclipses
 	}
 }
 
@@ -643,10 +644,1181 @@ verrier_on_yearly_pulse = {
 	}
 }
 
+verrier_on_yearly_pulse_solar_eclipses = {
+	effect = {
+		###### ANNULAR/TOTAL ECLIPSES 1836-1935 (random ones outside this range is in verrier_on_five_year_pulse_country)######
+		if {
+			limit = {
+				year = 1836
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1836_may
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 135 #May 15th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1836_nov
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 308 #Nov 4th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1838
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1838_sep
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 260 #Sep 18th
+				}
+			}
+		}
+		else_if {
+			limit = {
+				year = 1838
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1838_sep
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 186 #Sep 18th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1839
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1839_mar
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 73 #Mar 15th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1839_sep
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 249 #Sep 7th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1840
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1840_mar
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 63 #Mar 4th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1840_aug
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 239 #Aug 27th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1842
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1842_jul
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 188 #Jul 8th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1842_dec
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 364 #Dec 31st
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1843
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1843_jun
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 177 #Jun 27th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1843_dec
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 253 #Dec 21st
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1846
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1846_apr
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 114 #Apr 25th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1846_oct
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 292 #Oct 20th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1847
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1847_apr
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 104 #Apr 15th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1847_oct
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 292 #Oct 9th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1849
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1849_feb
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 53 #Feb 23th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1850
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1850_feb
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 42 #Feb 12th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1850_aug
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 218 #Aug 7th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1851
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1851_feb
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 31 #Feb 1st
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1851_jul
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 208 #Jul 28th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1852
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1852_dec
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 345 #Dec 11th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1853
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1853_jun
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 156 #Jun 6th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1853_nov
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 333 #Nov 30th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1854
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1854_may
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 146 #May 26th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1854_nov
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 324 #Nov 20th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1856
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1856_apr
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 95 #Apr 5th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1856_sep
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 272 #Sep 29th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1857
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1857_mar
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 83 #Mar 25th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1857_sep
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 260 #Sep 18th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1858
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1858_mar
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 73 #Mar 15th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1858_sep
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 249 #Sep 7th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1860
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1860_jul
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 199 #Jul 18th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1861
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1861_jan
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 10 #Jan 11th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1861_jul
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 188 #Jul 8th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1861_dec
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 364 #Dec 31st
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1864
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1864_may
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 126 #May 6th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1864_oct
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 303 #Oct 30th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1865
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1865_april
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 104 #Apr 25th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1865_oct
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 291 #Oct 19th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1867
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1867_mar
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 64 #Mar 6th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1867_aug
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 240 #Aug 29th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1868
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1868_feb
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 53 #Feb 23rd
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1868_aug
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 230 #Aug 18th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1869
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1869_feb
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 41 #Feb 11th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1869_aug
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 218 #Aug 7th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1870
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1870_dec
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 355 #Dec 22nd
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1871
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1871_jun
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 168 #Jun 18th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1871_dec
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 345 #Dec 12th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1872
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1872_jun
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 157 #Jun 6th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1874
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1874_apr
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 105 #Apr 16th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1874_oct
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 282 #Oct 10th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1875
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1875_apr
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 105 #Apr 6th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1875_sep
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 95 #Sep 29th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1876
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1876_mar
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 84 #Mar 25th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1878
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1878_feb
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 32 #Feb 2nd
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1878_jul
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 209 #Jul 29th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1879
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1879_jan
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 21 #Jan 22nd
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1879_jul
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 199 #Jul 19th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1880
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1880_jan
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 10 #Jan 11th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1882
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1882_may
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 138 #May 17th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1882_nov
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 313 #Nov 10th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1883
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1883_oct
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 302 #Oct 30th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1885
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1885_mar
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 74 #Mar 16th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1885_sep
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 250 #Sep 8th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1886
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1886_mar
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 63 #Mar 5th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1886_aug
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 240 #Aug 29th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1887
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1887_feb
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 52 #Feb 22nd
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1887_aug
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 230 #Aug 19th
+				}
+			}
+		}
+	}
+}
+
 verrier_on_five_year_pulse_country = {
 	effect = {
 		if = {
 			limit = {
+				OR = {
+					year <= 1835
+					year >= 1936
+				}
 				NOT = {
 					has_global_variable = verrier_solar_eclipse_active_var
 				}

--- a/common/on_actions/mr_science_verrier_on_actions.txt
+++ b/common/on_actions/mr_science_verrier_on_actions.txt
@@ -647,7 +647,7 @@ verrier_on_yearly_pulse = {
 verrier_on_yearly_pulse_solar_eclipses = {
 	effect = {
 		###### ANNULAR/TOTAL ECLIPSES 1836-1935 (random ones outside this range is in verrier_on_five_year_pulse_country)######
-		if {
+		if = {
 			limit = {
 				year = 1836
 			}
@@ -1910,6 +1910,20 @@ verrier_on_yearly_pulse_solar_eclipses = {
 					days = 167 #Jun 17th
 				}
 			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1890_dec
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 345 #Dec 12th
+				}
+			}
 		}
 		else_if = {
 			limit = {
@@ -1927,6 +1941,25 @@ verrier_on_yearly_pulse_solar_eclipses = {
 				trigger_event = {
 					id = verrier.152
 					days = 156 #Jun 6th
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				year = 1892
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1892_apr
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 116 #Apr 26th
 				}
 			}
 		}
@@ -2439,6 +2472,20 @@ verrier_on_yearly_pulse_solar_eclipses = {
 					days = 44 #Feb 14th
 				}
 			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1915_aug
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 221 #Aug 10th
+				}
+			}
 		}
 		else_if = {
 			limit = {
@@ -2557,6 +2604,17 @@ verrier_on_yearly_pulse_solar_eclipses = {
 					days = 97 #Apr 8th
 				}
 			}
+			every_country = {
+				limit = {
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1921_apr
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 189 #Oct 1st
+				}
+			}
 		}
 		else_if = {
 			limit = {
@@ -2642,6 +2700,17 @@ verrier_on_yearly_pulse_solar_eclipses = {
 					days = 23 #Jan 24th
 				}
 			}
+			every_country = {
+				limit = {
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1925_jul
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 200 #Jul 20th
+				}
+			}
 		}
 		else_if = {
 			limit = {
@@ -2659,6 +2728,17 @@ verrier_on_yearly_pulse_solar_eclipses = {
 				trigger_event = {
 					id = verrier.152
 					days = 13 #Jan 14th
+				}
+			}
+			every_country = {
+				limit = {
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1926_jul
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 189 #Jul 9th
 				}
 			}
 		}
@@ -2868,8 +2948,8 @@ verrier_on_five_year_pulse_country = {
 		if = {
 			limit = {
 				OR = {
-					year <= 1835
-					year >= 1936
+					year < 1836
+					year > 1935
 				}
 				NOT = {
 					has_global_variable = verrier_solar_eclipse_active_var

--- a/common/on_actions/mr_science_verrier_on_actions.txt
+++ b/common/on_actions/mr_science_verrier_on_actions.txt
@@ -699,25 +699,6 @@ verrier_on_yearly_pulse_solar_eclipses = {
 				}
 			}
 		}
-		else_if {
-			limit = {
-				year = 1838
-			}
-			every_country = {
-				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1838_sep
-						is_incorporated = yes
-					}
-					verrier_has_astronomer = yes
-					verrier_astronomical_observation = yes
-				}
-				trigger_event = {
-					id = verrier.152
-					days = 186 #Sep 18th
-				}
-			}
-		}
 		else_if = {
 			limit = {
 				year = 1839
@@ -846,7 +827,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 				}
 				trigger_event = {
 					id = verrier.152
-					days = 253 #Dec 21st
+					days = 354 #Dec 21st
 				}
 			}
 		}
@@ -1486,6 +1467,20 @@ verrier_on_yearly_pulse_solar_eclipses = {
 					days = 157 #Jun 6th
 				}
 			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1872_nov
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 334 #Nov 30th
+				}
+			}
 		}
 		else_if = {
 			limit = {
@@ -1569,6 +1564,20 @@ verrier_on_yearly_pulse_solar_eclipses = {
 				trigger_event = {
 					id = verrier.152
 					days = 84 #Mar 25th
+				}
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1876_sep
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 260 #Sep 17th
 				}
 			}
 		}
@@ -1656,6 +1665,20 @@ verrier_on_yearly_pulse_solar_eclipses = {
 					days = 10 #Jan 11th
 				}
 			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1880_jul
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 188 #Jul 17th
+				}
+			}
 		}
 		else_if = {
 			limit = {
@@ -1693,6 +1716,20 @@ verrier_on_yearly_pulse_solar_eclipses = {
 		else_if = {
 			limit = {
 				year = 1883
+			}
+			every_country = {
+				limit = {
+					any_owned_state = {
+						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1883_may
+						is_incorporated = yes
+					}
+					verrier_has_astronomer = yes
+					verrier_astronomical_observation = yes
+				}
+				trigger_event = {
+					id = verrier.152
+					days = 125 #May 6th
+				}
 			}
 			every_country = {
 				limit = {

--- a/common/on_actions/mr_science_verrier_on_actions.txt
+++ b/common/on_actions/mr_science_verrier_on_actions.txt
@@ -653,10 +653,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1836_may
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1836_may
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -667,10 +664,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1836_nov
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1836_nov
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -686,10 +680,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1838_sep
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1838_sep
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -705,10 +696,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1839_mar
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1839_mar
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -719,10 +707,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1839_sep
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1839_sep
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -738,10 +723,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1840_mar
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1840_mar
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -752,10 +734,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1840_aug
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1840_aug
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -771,10 +750,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1842_jul
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1842_jul
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -785,10 +761,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1842_dec
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1842_dec
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -804,10 +777,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1843_jun
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1843_jun
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -818,10 +788,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1843_dec
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1843_dec
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -837,10 +804,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1846_apr
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1846_apr
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -851,10 +815,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1846_oct
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1846_oct
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -870,10 +831,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1847_apr
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1847_apr
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -884,10 +842,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1847_oct
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1847_oct
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -903,10 +858,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1849_feb
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1849_feb
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -922,10 +874,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1850_feb
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1850_feb
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -936,10 +885,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1850_aug
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1850_aug
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -955,10 +901,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1851_feb
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1851_feb
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -969,10 +912,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1851_jul
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1851_jul
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -988,10 +928,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1852_dec
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1852_dec
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1007,10 +944,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1853_jun
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1853_jun
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1021,10 +955,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1853_nov
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1853_nov
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1040,10 +971,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1854_may
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1854_may
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1054,10 +982,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1854_nov
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1854_nov
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1073,10 +998,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1856_apr
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1856_apr
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1087,10 +1009,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1856_sep
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1856_sep
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1106,10 +1025,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1857_mar
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1857_mar
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1120,10 +1036,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1857_sep
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1857_sep
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1139,10 +1052,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1858_mar
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1858_mar
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1153,10 +1063,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1858_sep
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1858_sep
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1172,10 +1079,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1860_jul
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1860_jul
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1191,10 +1095,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1861_jan
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1861_jan
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1205,10 +1106,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1861_jul
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1861_jul
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1219,10 +1117,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1861_dec
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1861_dec
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1238,10 +1133,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1864_may
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1864_may
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1252,10 +1144,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1864_oct
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1864_oct
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1271,10 +1160,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1865_april
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1865_april
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1285,10 +1171,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1865_oct
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1865_oct
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1304,10 +1187,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1867_mar
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1867_mar
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1318,10 +1198,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1867_aug
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1867_aug
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1337,10 +1214,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1868_feb
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1868_feb
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1351,10 +1225,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1868_aug
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1868_aug
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1370,10 +1241,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1869_feb
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1869_feb
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1384,10 +1252,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1869_aug
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1869_aug
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1403,10 +1268,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1870_dec
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1870_dec
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1422,10 +1284,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1871_jun
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1871_jun
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1436,10 +1295,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1871_dec
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1871_dec
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1455,10 +1311,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1872_jun
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1872_jun
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1469,10 +1322,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1872_nov
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1872_nov
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1488,10 +1338,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1874_apr
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1874_apr
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1502,10 +1349,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1874_oct
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1874_oct
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1521,10 +1365,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1875_apr
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1875_apr
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1535,10 +1376,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1875_sep
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1875_sep
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1554,10 +1392,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1876_mar
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1876_mar
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1568,10 +1403,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1876_sep
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1876_sep
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1587,10 +1419,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1878_feb
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1878_feb
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1601,10 +1430,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1878_jul
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1878_jul
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1620,10 +1446,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1879_jan
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1879_jan
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1634,10 +1457,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1879_jul
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1879_jul
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1653,10 +1473,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1880_jan
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1880_jan
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1667,10 +1484,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1880_jul
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1880_jul
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1686,10 +1500,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1882_may
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1882_may
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1700,10 +1511,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1882_nov
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1882_nov
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1719,10 +1527,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1883_may
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1883_may
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1733,10 +1538,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1883_oct
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1883_oct
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1752,10 +1554,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1885_mar
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1885_mar
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1766,10 +1565,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1885_sep
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1885_sep
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1785,10 +1581,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1886_mar
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1886_mar
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1799,10 +1592,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1886_aug
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1886_aug
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1818,10 +1608,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1887_feb
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1887_feb
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1832,10 +1619,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1887_aug
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1887_aug
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1851,10 +1635,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1889_jan
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1889_jan
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1865,10 +1646,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1889_jun
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1889_jun
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1879,10 +1657,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1889_dec
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1889_dec
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1898,10 +1673,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1890_jun
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1890_jun
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1912,10 +1684,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1890_dec
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1890_dec
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1931,10 +1700,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1890_jun
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1890_jun
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1950,10 +1716,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1892_apr
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1892_apr
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1969,10 +1732,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1893_apr
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1893_apr
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -1983,10 +1743,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1893_oct
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1893_oct
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2002,10 +1759,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1894_apr
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1894_apr
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2016,10 +1770,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1894_sep
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1894_sep
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2035,10 +1786,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1896_aug
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1896_aug
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2054,10 +1802,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1897_feb
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1897_feb
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2068,10 +1813,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1897_jul
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1897_jul
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2087,10 +1829,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1898_jan
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1898_jan
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2106,10 +1845,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1900_may
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1900_may
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2120,10 +1856,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1900_nov
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1900_nov
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2139,10 +1872,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1901_may
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1901_may
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2153,10 +1883,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1901_nov
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1901_nov
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2172,10 +1899,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1903_mar
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1903_mar
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2191,10 +1915,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1904_mar
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1904_mar
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2205,10 +1926,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1904_sep
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1904_sep
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2224,10 +1942,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1905_mar
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1905_mar
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2238,10 +1953,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1905_aug
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1905_aug
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2257,10 +1969,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1907_sep
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1907_sep
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2271,10 +1980,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1907_mar
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1907_mar
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2290,10 +1996,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1908_jan
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1908_jan
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2304,10 +2007,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1908_jun
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1908_jun
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2318,10 +2018,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1908_dec
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1908_dec
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2337,10 +2034,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1909_jun
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1909_jun
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2356,10 +2050,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1910_may
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1910_may
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2375,10 +2066,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1911_apr
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1911_apr
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2389,10 +2077,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1911_oct
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1911_oct
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2408,10 +2093,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1912_apr
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1912_apr
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2422,10 +2104,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1912_oct
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1912_oct
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2441,10 +2120,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1914_aug
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1914_aug
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2460,10 +2136,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1915_feb
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1915_feb
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2474,10 +2147,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1915_aug
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1915_aug
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2493,10 +2163,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1916_feb
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1916_feb
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2507,10 +2174,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1916_jul
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1916_jul
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2526,10 +2190,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1918_jun
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1918_jun
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2540,10 +2201,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1918_dec
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1918_dec
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2559,10 +2217,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1919_may
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1919_may
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2573,10 +2228,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1919_nov
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1919_nov
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2592,10 +2244,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1921_apr
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1921_apr
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2622,10 +2271,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1922_mar
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1922_mar
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2636,10 +2282,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1922_sep
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1922_sep
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2655,10 +2298,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1923_mar
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1923_mar
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2669,10 +2309,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1923_sep
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1923_sep
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2688,10 +2325,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1925_jan
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1925_jan
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2718,10 +2352,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1926_jan
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1926_jan
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2748,10 +2379,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1927_jan
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1927_jan
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2762,10 +2390,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1927_jun
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1927_jun
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2781,10 +2406,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1929_may
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1929_may
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2795,10 +2417,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1929_nov
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1929_nov
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2814,10 +2433,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1930_apr
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_hybrid_1930_apr
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2828,10 +2444,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1930_oct
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1930_oct
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2847,10 +2460,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1932_mar
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1932_mar
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2861,10 +2471,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1932_aug
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1932_aug
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2880,10 +2487,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1933_feb
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1933_feb
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2894,10 +2498,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1933_aug
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1933_aug
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2913,10 +2514,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1934_feb
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_total_1934_feb
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}
@@ -2927,10 +2525,7 @@ verrier_on_yearly_pulse_solar_eclipses = {
 			}
 			every_country = {
 				limit = {
-					any_owned_state = {
-						is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1934_aug
-						is_incorporated = yes
-					}
+					is_in_geographic_region = verrier_geographic_region_solar_eclipse_annular_1934_aug
 					verrier_has_astronomer = yes
 					verrier_astronomical_observation = yes
 				}


### PR DESCRIPTION
Based on NASA's Annular/Total/Hybrid Solar Eclipses data, as seen at https://eclipse.gsfc.nasa.gov/SEcat5/SE1801-1900.html and https://eclipse.gsfc.nasa.gov/SEcat5/SE1901-2000.html, the criteria are that at least 80% of the sun has been covered for 100% of the entire state/50%+ of the entire strategic region.

For years outside Victoria 3's default range, the previous code behaviour will be used instead.

I've added all the relevant geographical region data and date calculation - but I cannot get the code to work in-game for some unknown reason, so I'm marking it as WIP for now.
