### PR TITLE
Tweaked Korean Empire Science Academy Name Trigger

### DIFF
--- a/common/customizable_localization/mr_science_academics_customizable_localization.txt
+++ b/common/customizable_localization/mr_science_academics_customizable_localization.txt
@@ -936,8 +936,7 @@ academics_scientific_society_generic_name_custom_loc = {
 				was_formed_from = KOR
 			}
 			coa_monarchy_trigger = yes
-			is_country_type = recognized
-			country_rank > rank_value:minor_power
+			has_variable = KOR_korean_empire_declared
 		}
 		localization_key = academics_KOR_daehan_jeguk_haksurwon
 	}


### PR DESCRIPTION
Academy of Sciences flavor name for Korea (`Daehan Jeguk Haksurwon`) trigger has been adjusted to check for when the `Proclaim the Empire of Korea` decision is taken to sync the name of the academy with the new name of the country